### PR TITLE
ラーニングセッションの新規作成と初期化の実装

### DIFF
--- a/fabbrica/index.ts
+++ b/fabbrica/index.ts
@@ -796,7 +796,6 @@ defineAdminFactory.withTransientFields = defaultTransientFieldValues => options 
 type LearningSessionScalarOrEnumFields = {
     title: string;
     accessCode: string;
-    isActive: boolean;
 };
 
 type LearningSessionteacherFactory = {
@@ -857,8 +856,7 @@ function autoGenerateLearningSessionScalarsOrEnums({ seq }: {
 }): LearningSessionScalarOrEnumFields {
     return {
         title: getScalarFieldValueGenerator().String({ modelName: "LearningSession", fieldName: "title", isId: false, isUnique: false, seq }),
-        accessCode: getScalarFieldValueGenerator().String({ modelName: "LearningSession", fieldName: "accessCode", isId: false, isUnique: false, seq }),
-        isActive: getScalarFieldValueGenerator().Boolean({ modelName: "LearningSession", fieldName: "isActive", isId: false, isUnique: false, seq })
+        accessCode: getScalarFieldValueGenerator().String({ modelName: "LearningSession", fieldName: "accessCode", isId: false, isUnique: true, seq })
     };
 }
 
@@ -1135,12 +1133,12 @@ type QuestionFactoryDefineInput = {
     id?: string;
     order?: number;
     title?: string;
-    description?: string | null;
+    description?: string;
     updatedAt?: Date;
     session: QuestionsessionFactory | Prisma.LearningSessionCreateNestedOneWithoutQuestionsInput;
     options?: Prisma.OptionCreateNestedManyWithoutQuestionInput;
     responses?: Prisma.ResponseCreateNestedManyWithoutQuestionInput;
-    defaultOption: QuestiondefaultOptionFactory | Prisma.OptionCreateNestedOneWithoutDefaultForQuestionInput;
+    defaultOption?: QuestiondefaultOptionFactory | Prisma.OptionCreateNestedOneWithoutDefaultForQuestionInput;
 };
 
 type QuestionTransientFields = Record<string, unknown> & Partial<Record<keyof QuestionFactoryDefineInput, never>>;
@@ -1307,7 +1305,7 @@ type OptionFactoryDefineInput = {
     id?: string;
     order?: number;
     title?: string;
-    description?: string | null;
+    description?: string;
     rewardMessage?: string | null;
     rewardPoints?: number;
     effect?: boolean;

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -6,6 +6,7 @@ const createJestConfig = nextJest({
 });
 
 const config: Config = {
+  verbose: true,
   coverageProvider: "v8",
   testEnvironment: "node", // or "jsdom"
 };

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint": "next lint",
     "test": "jest",
     "test:watch": "jest --watch",
-    "test:file": "jest --verbose --runInBand --no-cache --"
+    "test:file": "jest --verbose --"
   },
   "prisma": {
     "seed": "ts-node --compiler-options {\"module\":\"CommonJS\"} prisma/seed.ts"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "start": "next start",
     "lint": "next lint",
     "test": "jest",
-    "test:watch": "jest --watch"
+    "test:watch": "jest --watch",
+    "test:file": "jest --verbose --runInBand --no-cache --"
   },
   "prisma": {
     "seed": "ts-node --compiler-options {\"module\":\"CommonJS\"} prisma/seed.ts"

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -89,8 +89,8 @@ model LearningSession {
   id          String   @id @default(cuid())
   teacherId   String   @map("teacher_id")
   title       String
-  accessCode  String   @map("access_code")
-  isActive    Boolean  @map("is_active")
+  accessCode  String   @unique @map("access_code")
+  isActive    Boolean  @default(true) @map("is_active")
   createdAt   DateTime @default(now()) @map("created_at")
   updatedAt   DateTime @updatedAt @map("updated_at")
 
@@ -98,6 +98,8 @@ model LearningSession {
   enrollments SessionEnrollment[]
   questions   Question[]
 
+  @@index([teacherId])
+  @@index([accessCode]) 
   @@map("learning_sessions")
 }
 
@@ -109,6 +111,7 @@ model SessionEnrollment {
   learningSession   LearningSession @relation(fields: [sessionId], references: [id], onDelete: Cascade)
   student           Student         @relation(fields: [studentId], references: [userId], onDelete: Cascade)
 
+  @@index([studentId])
   @@id([sessionId, studentId])
   @@map("session_enrollments")
 }
@@ -119,15 +122,16 @@ model Question {
   sessionId          String   @map("session_id")
   order              Int
   title              String
-  description        String?
-  defaultOptionId    String   @unique @map("default_option_id")
+  description        String   @default("")
+  defaultOptionId    String?  @unique @map("default_option_id")
   updatedAt          DateTime @updatedAt @map("updated_at")
 
   session            LearningSession @relation(fields: [sessionId], references: [id], onDelete: Cascade)
   options            Option[]
   responses          Response[]
-  defaultOption      Option   @relation("DefaultOption", fields: [defaultOptionId], references: [id])
+  defaultOption      Option?  @relation("DefaultOption", fields: [defaultOptionId], references: [id])
 
+  @@index([sessionId])
   @@map("questions")
 }
 
@@ -137,7 +141,7 @@ model Option {
   questionId     String   @map("question_id")
   order          Int
   title          String
-  description    String?
+  description    String   @default("")
   rewardMessage  String?  @map("reward_message")
   rewardPoints   Int      @default(0) @map("reward_points")
   effect         Boolean  @default(false)
@@ -147,6 +151,7 @@ model Option {
   responses           Response[]
   defaultForQuestion  Question? @relation("DefaultOption")
 
+  @@index([questionId])
   @@map("options")
 }
 
@@ -164,6 +169,5 @@ model Response {
 
   @@index([questionId, optionId])
   @@index([studentId])
-
   @@map("responses")
 }

--- a/src/__tests__/integration01.test.ts
+++ b/src/__tests__/integration01.test.ts
@@ -1,13 +1,9 @@
-import UserService, { teacherUserSchema } from "@/app/_services/userService";
-import SessionService, {
-  fullSessionSchema,
-} from "@/app/_services/sessionService";
+import UserService from "@/app/_services/userService";
+import SessionService from "@/app/_services/sessionService";
 import { Prisma as PRS } from "@prisma/client";
 import { Role } from "@/app/_types/UserTypes";
 import { v4 as uuid } from "uuid";
 import { PrismaClient } from "@prisma/client";
-import { Ruthie } from "next/font/google";
-import { use } from "react";
 
 interface SessionSeed {
   id?: string;
@@ -36,7 +32,7 @@ const studentWithEnrollmentsSchema = {
   },
 } as const;
 
-const testUserIdPrefix = "TEST-";
+const testUserIdPrefix = "TEST-I01-";
 const fabricateTestUserId = () => testUserIdPrefix + uuid().substring(0, 8);
 const Timeout = 30 * 1000;
 
@@ -141,7 +137,7 @@ describe("教員のLS作成と取得、学生のLS参加と取得のテスト", 
     );
   });
 
-  if (false) {
+  if (true) {
     describe("全てのLSの一覧（日付 desc [新]→[旧] の順番）の取得", () => {
       //prettier-ignore
       it("成功する", async () => {

--- a/src/__tests__/integration01.test.ts
+++ b/src/__tests__/integration01.test.ts
@@ -1,0 +1,240 @@
+import UserService, { teacherUserSchema } from "@/app/_services/userService";
+import SessionService, {
+  fullSessionSchema,
+} from "@/app/_services/sessionService";
+import { Prisma as PRS } from "@prisma/client";
+import { Role } from "@/app/_types/UserTypes";
+import { v4 as uuid } from "uuid";
+import { PrismaClient } from "@prisma/client";
+import { Ruthie } from "next/font/google";
+import { use } from "react";
+
+interface SessionSeed {
+  id?: string;
+  title: string;
+  accessCode: string;
+}
+
+interface TeacherSeed {
+  id?: string;
+  displayName: string;
+  sessions: SessionSeed[];
+}
+
+interface StudentSeed {
+  id?: string;
+  displayName: string;
+}
+
+const studentWithEnrollmentsSchema = {
+  include: {
+    student: {
+      include: {
+        enrollments: true,
+      },
+    },
+  },
+} as const;
+
+const testUserIdPrefix = "TEST-";
+const fabricateTestUserId = () => testUserIdPrefix + uuid().substring(0, 8);
+const Timeout = 30 * 1000;
+
+describe("教員のLS作成と取得、学生のLS参加と取得のテスト", () => {
+  let prisma: PrismaClient;
+  let userService: UserService;
+  let sessionService: SessionService;
+
+  let teachers: TeacherSeed[] = [
+    { displayName: "高負荷 耐子", sessions: [] },
+    { displayName: "不具合 直志", sessions: [] },
+    { displayName: "凝集 高夫", sessions: [] },
+  ];
+  let students: StudentSeed[] = [
+    { displayName: "構文 誤次郎" },
+    { displayName: "仕様 曖昧子" },
+    { displayName: "保守 絶望太" },
+    { displayName: "負債 雪崩美" },
+  ];
+
+  beforeAll(async () => {
+    prisma = new PrismaClient();
+    userService = new UserService(prisma);
+    sessionService = new SessionService(prisma);
+    teachers.forEach((teacher) => (teacher.id = fabricateTestUserId()));
+    students.forEach((student) => (student.id = fabricateTestUserId()));
+  });
+
+  afterAll(async () => {
+    await prisma.user.deleteMany({
+      where: { id: { startsWith: testUserIdPrefix } },
+    });
+  });
+
+  describe("ユーザ（学生ロール）の新規作成", () => {
+    it("成功する", async () => {
+      const users = [...teachers, ...students];
+      const createdUsers = await Promise.all(
+        users.map(({ id, displayName }) =>
+          userService.createAsStudent(id!, displayName)
+        )
+      );
+      createdUsers.forEach((user) => expect(user.role).toBe(Role.STUDENT));
+    });
+  });
+
+  describe("指定ユーザの教員ロール昇格", () => {
+    it("教員ロールへの昇格に成功した", async () => {
+      const updatedUsers = await Promise.all(
+        teachers.map(({ id }) => userService.updateRole(id!, Role.TEACHER))
+      );
+      updatedUsers.forEach((user) => expect(user.role).toBe(Role.TEACHER));
+    });
+  });
+
+  describe("教員0（高負荷 耐子）がLSを新規", () => {
+    //prettier-ignore
+    it("成功する", async () => {
+        const teacher = teachers[0];
+        teacher.sessions.push(
+          { title: "プログラミング基礎演習（第01回）", accessCode: "990-0001" },
+          { title: "プログラミング基礎演習（第02回）", accessCode: "990-0002" },
+          { title: "プログラミング基礎演習（第03回）", accessCode: "990-0003" }
+        );
+        // あえて1.1秒のウエイトを入れて追加
+        for (const session of teacher.sessions) {
+          await new Promise((resolve) => setTimeout(resolve, 1100));
+          //prettier-ignore
+          const createdSession = await sessionService.create(
+            teacher.id!, session.title, session.accessCode );
+          session.id = createdSession.id;
+          expect(createdSession.title).toBe(session.title);
+          expect(createdSession.accessCode).toBe(session.accessCode);
+        }
+      },
+      Timeout
+    );
+  });
+
+  describe("教員1（不具合 直志）がLSを新規", () => {
+    //prettier-ignore
+    it("成功する", async () => {
+        const teacher = teachers[1];
+        teacher.sessions.push(
+          { title: "データベース工学（第03回）", accessCode: "991-0001" },
+          { title: "データベース工学（第05回）", accessCode: "991-0002" },
+          { title: "データベース工学（第07回）", accessCode: "991-0003" },
+          { title: "データベース工学（第14回）", accessCode: "991-0004" },
+        );
+        // ここでは追加順序が意味を持つので Promise.all は使わない
+        for (const session of teacher.sessions) {
+          //prettier-ignore
+          const createdSession = await sessionService.create(
+            teacher.id!, session.title, session.accessCode );
+          session.id = createdSession.id;
+          expect(createdSession.title).toBe(session.title);
+          expect(createdSession.accessCode).toBe(session.accessCode);
+          // await new Promise((resolve) => setTimeout(resolve, 1100));
+        }
+      },
+      Timeout
+    );
+  });
+
+  if (false) {
+    describe("全てのLSの一覧（日付 desc [新]→[旧] の順番）の取得", () => {
+      //prettier-ignore
+      it("成功する", async () => {
+        // 引数省略すると updatedAtが 降順（Desc）新しい日付から古い日付になる
+        const sessions = await sessionService.getAll();
+        expect(sessions.length).toBe(teachers.reduce((acc, teacher) => acc + teacher.sessions.length, 0));
+        expect(sessions).toEqual([...sessions].sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime()));
+      }
+    );
+    });
+
+    describe("全てのLSの一覧（日付 asc [旧]→[新] の順番）の取得", () => {
+      //prettier-ignore
+      it("成功する", async () => {
+        const sessions = await sessionService.getAll(undefined,"updatedAt", "asc");
+        expect(sessions).toEqual([...sessions].sort((a, b) => a.updatedAt.getTime() - b.updatedAt.getTime()));
+      }
+    );
+    });
+
+    describe("全てのLSの一覧（タイトル昇順）の取得", () => {
+      //prettier-ignore
+      it("成功する", async () => {
+        const sessions = await sessionService.getAll(undefined,"title", "asc"); 
+        expect(sessions).toEqual([...sessions].sort((a, b) => a.title.localeCompare(b.title)));
+      }
+    );
+    });
+
+    describe("全てのLSの一覧（タイトル降順）の取得", () => {
+      //prettier-ignore
+      it("成功する", async () => {
+        const sessions = await sessionService.getAll(undefined,"title", "desc"); 
+        expect(sessions).toEqual([...sessions].sort((a, b) => b.title.localeCompare(a.title)));
+      }
+    );
+    });
+  }
+
+  describe("教員0（高負荷 耐子）のLSの取得", () => {
+    // prettier-ignore
+    it("成功する", async () => {
+      const teacher = teachers[0];
+      // 引数省略すると updatedAtが 降順（Desc）新しい日付から古い日付になる
+      const sessions = await sessionService.getAllByTeacherId(teacher.id!);
+      expect(sessions.length).toBe(teacher.sessions.length);
+      expect(sessions).toEqual([...sessions].sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime()));      
+    });
+  });
+
+  describe("教員1（不具合 直志）のLSの取得", () => {
+    // prettier-ignore
+    it("成功する", async () => {
+      const teacher = teachers[1];
+      const sessions = await sessionService.getAllByTeacherId(teacher.id!);
+      expect(sessions.length).toBe(teacher.sessions.length);
+      expect(sessions).toEqual([...sessions].sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime()));      
+    });
+  });
+
+  describe("学生0（構文 誤次郎）がLSに参加", () => {
+    it(
+      "成功する",
+      async () => {
+        const student = students[0];
+        // 全ての教員のセッションに参加
+        await Promise.all(
+          // flatMap を使用すること
+          teachers.flatMap((teacher) =>
+            teacher.sessions.map((session) =>
+              sessionService.enrollStudent(session.id!, student.id!)
+            )
+          )
+        );
+        // 参加したセッションの数を確認(1)
+        const sessions = await sessionService.getAllByStudentId(student.id!);
+        console.log(JSON.stringify(sessions, null, 2));
+        expect(sessions.length).toBe(
+          teachers.reduce((acc, teacher) => acc + teacher.sessions.length, 0)
+        );
+
+        // Student に Session が紐づいていることを確認
+        const fetchedStudent = (await userService.getById(
+          student.id!,
+          studentWithEnrollmentsSchema
+        )) as PRS.UserGetPayload<typeof studentWithEnrollmentsSchema>;
+        expect(sessions.length).toBe(
+          fetchedStudent.student?.enrollments.length
+        );
+      },
+      Timeout
+    );
+  });
+
+  //
+});

--- a/src/__tests__/passing.test.ts
+++ b/src/__tests__/passing.test.ts
@@ -1,8 +1,0 @@
-import { describe, it, expect } from "@jest/globals";
-
-// TODO: Jestの練習（最終的には削除）
-describe("Passing test", () => {
-  it("should always pass", () => {
-    expect(true).toBe(true);
-  });
-});

--- a/src/app/_services/questionService.ts
+++ b/src/app/_services/questionService.ts
@@ -1,0 +1,78 @@
+import { PrismaClient } from "@prisma/client";
+import { optionSetSize } from "@/config/app-config";
+import type { Question } from "@prisma/client";
+import { withErrorHandling } from "@/app/_services/servicesExceptions";
+import { Prisma as PRS } from "@prisma/client";
+
+export type QuestionReturnType<
+  T extends PRS.QuestionInclude,
+  U extends PRS.QuestionSelect
+> = {
+  include?: T;
+  select?: U;
+};
+
+class QuestionService {
+  private prisma: PrismaClient;
+
+  constructor(prisma: PrismaClient) {
+    this.prisma = prisma;
+  }
+
+  // 設問の取得
+  @withErrorHandling()
+  public async findSession<
+    T extends PRS.QuestionInclude,
+    U extends PRS.QuestionSelect
+  >(
+    sessionId: string,
+    options?: QuestionReturnType<T, U>
+  ): Promise<PRS.QuestionGetPayload<{ include: T; select: U }>> {
+    const question = (await this.prisma.question.findUniqueOrThrow({
+      where: { id: sessionId },
+      ...options,
+    })) as PRS.QuestionGetPayload<{ include: T; select: U }>;
+    return question;
+  }
+
+  // 設問の新規作成・初期化
+  @withErrorHandling()
+  public async createQuestion(
+    sessionId: string,
+    order: number = 1
+  ): Promise<Question> {
+    // 1. 設問の作成
+    const question = await this.prisma.question.create({
+      data: {
+        sessionId,
+        order,
+        title: "設問X",
+      },
+    });
+
+    // 2. 選択肢群の作成
+    const initialOptionSet = Array.from({ length: optionSetSize }, (_, i) => ({
+      questionId: question.id,
+      order: i + 1,
+      title: `選択肢${i + 1}`,
+    }));
+
+    await this.prisma.option.createMany({
+      data: initialOptionSet,
+    });
+
+    // 3. 選択肢の取得 (createManyの戻値が使えないため)
+    const options = await this.prisma.option.findMany({
+      where: { questionId: question.id },
+      orderBy: { order: "asc" },
+    });
+
+    // 4. 設問にデフォルト選択肢を設定
+    return await this.prisma.question.update({
+      where: { id: question.id },
+      data: { defaultOptionId: options[0].id },
+    });
+  }
+}
+
+export default QuestionService;

--- a/src/app/_services/servicesExceptions.ts
+++ b/src/app/_services/servicesExceptions.ts
@@ -3,6 +3,32 @@ import { Origin } from "@/app/_types/ApiResponse";
 import { StatusCodes } from "@/app/_utils/extendedStatusCodes";
 import { ApiError } from "@/app/api/_helpers/apiExceptions";
 
+// 共通の例外処理のためのエラーハンドリングデコレータ
+export const withErrorHandling = () => {
+  return (target: any, propertyKey: string, descriptor: PropertyDescriptor) => {
+    const originalMethod = descriptor.value;
+    descriptor.value = async function (...args: any[]) {
+      try {
+        return await originalMethod.apply(this, args);
+      } catch (error: unknown) {
+        if (error instanceof ApiError) {
+          throw error;
+        }
+        const className = this.constructor.name;
+        let msg = `Error in ${className}.${propertyKey}: `;
+        if (error instanceof Error) {
+          msg += error.message;
+        } else if (error !== null && error !== undefined) {
+          msg += String(error);
+        }
+        throw new DatabaseOperationError(msg, error);
+      }
+    };
+
+    return descriptor;
+  };
+};
+
 export const DomainRuleViolationError = class extends ApiError {
   readonly httpStatus: StatusCodes = StatusCodes.BAD_REQUEST;
   readonly appErrorCode: string = AppErrorCode.DOMAIN_RULE_VIOLATION;

--- a/src/app/_services/sessionService.test.ts
+++ b/src/app/_services/sessionService.test.ts
@@ -1,0 +1,137 @@
+import UserService from "./userService";
+import SessionService, { fullSessionSchema } from "./sessionService";
+import { Prisma as PRS } from "@prisma/client";
+import { Role } from "@/app/_types/UserTypes";
+import { v4 as uuidv4 } from "uuid";
+import { PrismaClient } from "@prisma/client";
+import { optionSetSize } from "@/config/app-config";
+import { DomainRuleViolationError } from "@/app/_services/servicesExceptions";
+
+describe("LearningSessionServiceのテスト", () => {
+  let prisma: PrismaClient;
+  let teacherId: string;
+  let sessionId: string;
+  let userService: UserService;
+  let sessionService: SessionService;
+
+  const seeds = Array.from({ length: 3 }, (_, i) => ({
+    title: `セッション-${uuidv4().substring(0, 8)}`,
+    accessCode: `999-${(i + 1).toString().padStart(4, "0")}`,
+  }));
+
+  beforeAll(async () => {
+    teacherId = `TEST-${uuidv4().substring(0, 8)}`;
+    prisma = new PrismaClient();
+    userService = new UserService(prisma);
+    sessionService = new SessionService(prisma);
+  });
+
+  afterAll(async () => {
+    await prisma.user.delete({
+      where: {
+        id: teacherId,
+      },
+    });
+    await prisma.$disconnect();
+  });
+
+  describe("教員ロールのテストユーザの作成", () => {
+    it("成功する", async () => {
+      await userService.createAsStudent(teacherId, "不具合 直志");
+      const teacher = await userService.updateRole(teacherId, Role.TEACHER);
+      expect(teacher.role).toBe(Role.TEACHER);
+    });
+  });
+
+  describe("ラーニングセッション（LS）の新規作成", () => {
+    it("成功する", async () => {
+      const session = await sessionService.create(
+        teacherId,
+        seeds[0].title,
+        seeds[0].accessCode
+      );
+      sessionId = session.id;
+      const question = session.questions[0];
+
+      // 1つの設問が作成されていること
+      expect(session.questions.length).toBe(1);
+
+      // 設問はoptionSetSize(6個)の選択肢を持っていること
+      expect(question.options.length).toBe(optionSetSize);
+
+      // 設問のデフォルト選択肢が、最初の選択肢になっていること
+      expect(question.defaultOptionId).toBe(question.options[0].id);
+
+      // console.log(JSON.stringify(session, null, 2));
+    });
+  });
+
+  describe("LSのIdによる取得", () => {
+    it("成功する", async () => {
+      const session = (await sessionService.getById(
+        sessionId,
+        fullSessionSchema
+      )) as PRS.LearningSessionGetPayload<typeof fullSessionSchema>;
+
+      // const session = await sessionService.getById(sessionId);
+
+      expect(session).not.toBe(null);
+      // console.log(JSON.stringify(session, null, 2));
+    });
+  });
+
+  describe("重複したアクセスコードを引数にLSの新規作成", () => {
+    it("失敗する", async () => {
+      await expect(
+        sessionService.create(teacherId, seeds[0].title, seeds[0].accessCode)
+      ).rejects.toThrow(DomainRuleViolationError);
+    });
+  });
+
+  describe("存在しないUserIdを引数にLSの新規作成", () => {
+    it("失敗する", async () => {
+      await expect(
+        sessionService.create("hoge", seeds[1].title, seeds[1].accessCode)
+      ).rejects.toThrow(DomainRuleViolationError);
+    });
+  });
+
+  describe(`LSの追加作成（${seeds.length - 1}個）`, () => {
+    it("成功する", async () => {
+      const sessionsSeeds2 = seeds.slice(1); // 先頭を除く
+      const sessions = await Promise.all(
+        sessionsSeeds2.map(({ title, accessCode }) =>
+          sessionService.create(teacherId, title, accessCode)
+        )
+      );
+      sessions.forEach((session, index) => {
+        expect(session.title).toBe(sessionsSeeds2[index].title);
+        expect(session.accessCode).toBe(sessionsSeeds2[index].accessCode);
+      });
+    });
+  });
+
+  describe("LSの削除（設問と選択肢のカスケード削除）", () => {
+    it("成功する", async () => {
+      // LSの削除
+      await sessionService.delete(sessionId);
+      // LSに紐づいた設問が削除されていること
+      const questions = await prisma.question.findMany({
+        where: {
+          sessionId,
+        },
+      });
+      expect(questions.length).toBe(0);
+
+      // LSに紐づいた設問に紐づいた選択肢も削除されていること
+      const options = await prisma.option.findMany({
+        where: {
+          question: {
+            sessionId,
+          },
+        },
+      });
+      expect(options.length).toBe(0);
+    });
+  });
+});

--- a/src/app/_services/sessionService.ts
+++ b/src/app/_services/sessionService.ts
@@ -1,0 +1,197 @@
+import { LearningSession, PrismaClient } from "@prisma/client";
+import { Prisma as PRS, Role } from "@prisma/client";
+import {
+  DomainRuleViolationError,
+  withErrorHandling,
+} from "@/app/_services/servicesExceptions";
+import QuestionService from "@/app/_services/questionService";
+
+export type SessionReturnType<
+  T extends PRS.LearningSessionInclude,
+  U extends PRS.LearningSessionSelect
+> = {
+  include?: T;
+  select?: U;
+};
+
+export const fullSessionSchema = {
+  include: {
+    questions: {
+      include: {
+        options: true,
+      },
+    },
+  },
+} as const;
+
+type CreateSessionReturnType = PRS.LearningSessionGetPayload<
+  typeof fullSessionSchema
+>;
+
+// LearningSessionのCRUD操作を行なうクラス
+class SessionService {
+  private prisma: PrismaClient;
+
+  constructor(prisma: PrismaClient) {
+    this.prisma = prisma;
+  }
+
+  // Idによるラーニングセッション（単数）の取得。該当なしは例外をスロー
+  @withErrorHandling()
+  public async getById<
+    T extends PRS.LearningSessionInclude,
+    U extends PRS.LearningSessionSelect
+  >(
+    sessionId: string,
+    options?: SessionReturnType<T, U>
+  ): Promise<PRS.LearningSessionGetPayload<{ include: T; select: U }>> {
+    return (await this.prisma.learningSession.findUniqueOrThrow({
+      where: { id: sessionId },
+      ...options,
+    })) as PRS.LearningSessionGetPayload<{ include: T; select: U }>;
+  }
+
+  // すべてのラーニングセッションの取得（Admin用途）
+  @withErrorHandling()
+  public async getAll<
+    T extends PRS.LearningSessionInclude,
+    U extends PRS.LearningSessionSelect
+  >(
+    options?: SessionReturnType<T, U>,
+    sortKey: "updatedAt" | "title" = "updatedAt",
+    sortDirection: "asc" | "desc" = "desc"
+  ): Promise<PRS.LearningSessionGetPayload<{ include: T; select: U }>[]> {
+    return (await this.prisma.learningSession.findMany({
+      orderBy: { [sortKey]: sortDirection },
+      ...options,
+    })) as PRS.LearningSessionGetPayload<{ include: T; select: U }>[];
+  }
+
+  // 指定IDの [教員] が作成した LS の取得
+  @withErrorHandling()
+  public async getAllByTeacherId<
+    T extends PRS.LearningSessionInclude,
+    U extends PRS.LearningSessionSelect
+  >(
+    teacherId: string,
+    options?: SessionReturnType<T, U>,
+    sortKey: "updatedAt" | "title" = "updatedAt",
+    sortDirection: "asc" | "desc" = "desc"
+  ): Promise<PRS.LearningSessionGetPayload<{ include: T; select: U }>[]> {
+    return (await this.prisma.learningSession.findMany({
+      where: { teacherId },
+      orderBy: { [sortKey]: sortDirection },
+      ...options,
+    })) as PRS.LearningSessionGetPayload<{ include: T; select: U }>[];
+  }
+
+  // 指定IDの [学生] が参加している LS の取得
+  @withErrorHandling()
+  public async getAllByStudentId<
+    T extends PRS.LearningSessionInclude,
+    U extends PRS.LearningSessionSelect
+  >(
+    studentId: string,
+    options?: SessionReturnType<T, U>,
+    sortKey: "updatedAt" | "title" = "updatedAt",
+    sortDirection: "asc" | "desc" = "desc"
+  ): Promise<PRS.LearningSessionGetPayload<{ include: T; select: U }>[]> {
+    return (await this.prisma.learningSession.findMany({
+      where: {
+        enrollments: {
+          some: {
+            studentId: studentId,
+          },
+        },
+      },
+      orderBy: { [sortKey]: sortDirection },
+      ...options,
+    })) as PRS.LearningSessionGetPayload<{ include: T; select: U }>[];
+  }
+
+  // ラーニングセッションの名前の変更
+  @withErrorHandling()
+  public async updateTitle(sessionId: string, title: string): Promise<void> {
+    try {
+      await this.prisma.learningSession.update({
+        where: { id: sessionId },
+        data: { title },
+      });
+    } catch (error: any) {
+      if (error.code === "P2025") {
+        throw new DomainRuleViolationError(
+          "指定IDのラーニングセッションが存在せず、名前の変更に失敗しました",
+          { sessionId, title }
+        );
+      }
+      throw error;
+    }
+  }
+
+  // ラーニングセッションの新規作成と初期化
+  @withErrorHandling()
+  public async create(
+    teacherId: string,
+    title: string,
+    accessCode: string
+  ): Promise<CreateSessionReturnType> {
+    // 1. セッションの作成
+    let session: LearningSession | null;
+    try {
+      session = await this.prisma.learningSession.create({
+        data: {
+          teacherId,
+          accessCode,
+          title,
+        },
+      });
+    } catch (error: any) {
+      if (error.code === "P2002") {
+        throw new DomainRuleViolationError(
+          `Unique constraint failed on the accessCode ${accessCode}`,
+          { teacherId, title, accessCode }
+        );
+      } else if (error.code === "P2003") {
+        throw new DomainRuleViolationError(
+          `FK constraint failed on the teacherId ${teacherId}`,
+          { teacherId, title, accessCode }
+        );
+      }
+      throw error;
+    }
+
+    // 2. 設問の作成
+    const questionService = new QuestionService(this.prisma);
+    await questionService.createQuestion(session.id);
+
+    // 3. 設問と選択肢を含めた完全なセッション情報の再取得
+    return (await this.getById(
+      session.id,
+      fullSessionSchema
+    )) as CreateSessionReturnType;
+  }
+
+  // ラーニングセッションに参加する学生の登録
+  @withErrorHandling()
+  public async enrollStudent(
+    sessionId: string,
+    studentId: string
+  ): Promise<void> {
+    await this.prisma.sessionEnrollment.create({
+      data: {
+        sessionId,
+        studentId,
+      },
+    });
+  }
+
+  // ラーニングセッションの削除
+  @withErrorHandling()
+  public async delete(sessionId: string): Promise<void> {
+    await this.prisma.learningSession.delete({
+      where: { id: sessionId },
+    });
+  }
+}
+
+export default SessionService;

--- a/src/app/_services/sessionService.ts
+++ b/src/app/_services/sessionService.ts
@@ -1,5 +1,5 @@
 import { LearningSession, PrismaClient } from "@prisma/client";
-import { Prisma as PRS, Role } from "@prisma/client";
+import { Prisma as PRS } from "@prisma/client";
 import {
   DomainRuleViolationError,
   withErrorHandling,

--- a/src/app/_services/sessionService.ts
+++ b/src/app/_services/sessionService.ts
@@ -109,7 +109,7 @@ class SessionService {
     })) as PRS.LearningSessionGetPayload<{ include: T; select: U }>[];
   }
 
-  // ラーニングセッションの名前の変更
+  // 名前（title属性）の変更
   @withErrorHandling()
   public async updateTitle(sessionId: string, title: string): Promise<void> {
     try {
@@ -128,7 +128,7 @@ class SessionService {
     }
   }
 
-  // ラーニングセッションの新規作成と初期化
+  // 新規作成と初期化（設問１個付き）
   @withErrorHandling()
   public async create(
     teacherId: string,

--- a/src/app/_types/ServiceTypes.ts
+++ b/src/app/_types/ServiceTypes.ts
@@ -1,9 +1,0 @@
-import { Prisma as P } from "@prisma/client";
-
-export type UserQueryOptions<
-  T extends P.UserInclude,
-  U extends P.UserSelect
-> = {
-  include?: T;
-  select?: U;
-};

--- a/src/app/_types/SessionTypes.ts
+++ b/src/app/_types/SessionTypes.ts
@@ -1,0 +1,5 @@
+import { z } from "zod";
+
+// フロントエンド <-> WebAPI層 の DTO
+// DB層の型定義（Prisma）のインポートは避けること
+// つまり import { Role } from "@prisma/client"; はあえて使わない

--- a/src/app/_types/UserTypes.ts
+++ b/src/app/_types/UserTypes.ts
@@ -1,9 +1,24 @@
-import { Role } from "@prisma/client";
 import { z } from "zod";
+
+// フロントエンド <-> WebAPI層 の DTO
+// DB層の型定義（Prisma）のインポートは避けること
+// つまり import { Role } from "@prisma/client"; はあえて使わない
+
+export const Role = {
+  ADMIN: "ADMIN",
+  TEACHER: "TEACHER",
+  STUDENT: "STUDENT",
+} as const;
+
+export type Role = (typeof Role)[keyof typeof Role];
+
+///////////////////////////////////////////////////////////////
 
 const requiredMsg = "必須入力の項目です。";
 const uuidRegex =
   /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+///////////////////////////////////////////////////////////////
 
 export interface UserId {
   id: string;
@@ -12,6 +27,8 @@ export interface UserId {
 export const userIdSchema = z.object({
   id: z.string().regex(uuidRegex, "不正な形式です。Invalid UUID format."),
 });
+
+///////////////////////////////////////////////////////////////
 
 export interface UserNewRole {
   id: string;
@@ -23,6 +40,8 @@ export const userNewRoleSchema = z.object({
   newRole: z.enum([Role.ADMIN, Role.TEACHER, Role.STUDENT]),
 });
 
+///////////////////////////////////////////////////////////////
+
 export interface UserAuth {
   email: string;
   password: string;
@@ -32,6 +51,8 @@ export const userAuthSchema = z.object({
   email: z.string().email("メールアドレスの形式で入力してください。"),
   password: z.string().min(6, "パスワードには6文字以上が必要です。"),
 });
+
+///////////////////////////////////////////////////////////////
 
 export interface UserProfile {
   id: string;

--- a/src/config/app-config.ts
+++ b/src/config/app-config.ts
@@ -5,6 +5,8 @@ export const isDevelopmentEnv =
 // API取得時の遅延時間（ミリ秒）
 export const apiDelay = 0;
 
+export const optionSetSize = 6;
+
 export const appBaseUrl = process.env.NEXT_PUBLIC_APP_BASE_URL;
 export const appName = "ProgressLens";
 export const avatarBucket = "img_avatar";


### PR DESCRIPTION
【実装の概要】
- バックエンド（DBアクセス層）においてのラーニングセッションの新規作成と初期化処理（教員・設問・回答、学生とのリレーションを含む）を実装しました。具体的には、ラーニングセッションに関するCRUD処理の一部を `SessionService` クラスとして実装しました。
    - `src/app/_services/sessionService.ts`
- `SessionService` 単体のテストコード、`SessionService` と `UserService` を組み合わせたテストコードを記述しました。
    - `src/app/_services/sessionService.test.ts`
    - `src/app/__test__/integration01.test.ts`
- サービスクラスに関連する型や変数名前の見直し、処理のリファクタリングをしました。ラーニングセッションの初期化処理に関連して `schema.prisma` も見直しました。

【特にレビューして頂きたいファイル】
- `sessionService.ts`
- `sessionService.test.ts`
- `integration01.test.ts`
- `schema.prisma`

【保留にしていること】
- `integration01.test.ts` で `describe("学生2がLSに参加",... )` と `describe("学生3\がLSに参加",... )` のコードが、ほぼ同じになっていること。
- `src/app/api/v1/session/route.ts` は書きかけです。無視してください。