### PR TITLE
ラーニングセッションの管理機能（フロントエンド）

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,6 +4,7 @@
     "fontawesome",
     "fortawesome",
     "hookform",
+    "immer",
     "shadcn",
     "signup",
     "tailwindcss",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@radix-ui/react-avatar": "^1.1.0",
         "@radix-ui/react-dialog": "^1.1.1",
         "@radix-ui/react-dropdown-menu": "^2.1.1",
+        "@radix-ui/react-label": "^2.1.0",
         "@radix-ui/react-slot": "^1.1.0",
         "@radix-ui/react-switch": "^1.1.0",
         "@radix-ui/react-tooltip": "^1.1.2",
@@ -2214,6 +2215,29 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-label": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-label/-/react-label-2.1.0.tgz",
+      "integrity": "sha512-peLblDlFw/ngk3UWq0VnYaOLy6agTZZ+MUO/WhVfm14vJGML+xH4FAl2XQGLqdefjNb7ApRg6Yn7U42ZhmYXdw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.0.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@prisma/client": "^5.19.0",
         "@radix-ui/react-accordion": "^1.2.0",
         "@radix-ui/react-avatar": "^1.1.0",
+        "@radix-ui/react-dialog": "^1.1.1",
         "@radix-ui/react-dropdown-menu": "^2.1.1",
         "@radix-ui/react-slot": "^1.1.0",
         "@radix-ui/react-switch": "^1.1.0",
@@ -2048,6 +2049,42 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.1.tgz",
+      "integrity": "sha512-zysS+iU4YP3STKNS6USvFVqI4qqx8EpiwmT5TuCApVEBca+eRCbONi4EgzfNSuVnOXvC5UPHHMjs8RXO6DH9Bg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.0",
+        "@radix-ui/react-compose-refs": "1.1.0",
+        "@radix-ui/react-context": "1.1.0",
+        "@radix-ui/react-dismissable-layer": "1.1.0",
+        "@radix-ui/react-focus-guards": "1.1.0",
+        "@radix-ui/react-focus-scope": "1.1.0",
+        "@radix-ui/react-id": "1.1.0",
+        "@radix-ui/react-portal": "1.1.1",
+        "@radix-ui/react-presence": "1.1.0",
+        "@radix-ui/react-primitive": "2.0.0",
+        "@radix-ui/react-slot": "1.1.0",
+        "@radix-ui/react-use-controllable-state": "1.1.0",
+        "aria-hidden": "^1.1.1",
+        "react-remove-scroll": "2.5.7"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@radix-ui/react-avatar": "^1.1.0",
     "@radix-ui/react-dialog": "^1.1.1",
     "@radix-ui/react-dropdown-menu": "^2.1.1",
+    "@radix-ui/react-label": "^2.1.0",
     "@radix-ui/react-slot": "^1.1.0",
     "@radix-ui/react-switch": "^1.1.0",
     "@radix-ui/react-tooltip": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@prisma/client": "^5.19.0",
     "@radix-ui/react-accordion": "^1.2.0",
     "@radix-ui/react-avatar": "^1.1.0",
+    "@radix-ui/react-dialog": "^1.1.1",
     "@radix-ui/react-dropdown-menu": "^2.1.1",
     "@radix-ui/react-slot": "^1.1.0",
     "@radix-ui/react-switch": "^1.1.0",

--- a/src/__tests__/integration01.test.ts
+++ b/src/__tests__/integration01.test.ts
@@ -1,6 +1,6 @@
 import UserService from "@/app/_services/userService";
 import SessionService, {
-  sessionWithEnrollmentsSchema,
+  forGetAllByTeacherIdSchema,
 } from "@/app/_services/sessionService";
 import { Prisma as PRS } from "@prisma/client";
 import { Role } from "@/app/_types/UserTypes";
@@ -70,24 +70,32 @@ describe("教員のLS作成と取得、学生のLS参加と取得のテスト", 
   });
 
   describe("ユーザ（学生ロール）の新規作成", () => {
-    it("成功する", async () => {
-      const users = [...teachers, ...students];
-      const createdUsers = await Promise.all(
-        users.map(({ id, displayName }) =>
-          userService.createAsStudent(id!, displayName)
-        )
-      );
-      createdUsers.forEach((user) => expect(user.role).toBe(Role.STUDENT));
-    });
+    it(
+      "成功する",
+      async () => {
+        const users = [...teachers, ...students];
+        const createdUsers = await Promise.all(
+          users.map(({ id, displayName }) =>
+            userService.createAsStudent(id!, displayName)
+          )
+        );
+        createdUsers.forEach((user) => expect(user.role).toBe(Role.STUDENT));
+      },
+      Timeout
+    );
   });
 
   describe("指定ユーザの教員ロール昇格", () => {
-    it("教員ロールへの昇格に成功した", async () => {
-      const updatedUsers = await Promise.all(
-        teachers.map(({ id }) => userService.updateRole(id!, Role.TEACHER))
-      );
-      updatedUsers.forEach((user) => expect(user.role).toBe(Role.TEACHER));
-    });
+    it(
+      "教員ロールへの昇格に成功した",
+      async () => {
+        const updatedUsers = await Promise.all(
+          teachers.map(({ id }) => userService.updateRole(id!, Role.TEACHER))
+        );
+        updatedUsers.forEach((user) => expect(user.role).toBe(Role.TEACHER));
+      },
+      Timeout
+    );
   });
 
   describe("教員0（高負荷 耐子）がLSを新規", () => {
@@ -147,7 +155,7 @@ describe("教員のLS作成と取得、学生のLS参加と取得のテスト", 
       it("成功する", async () => {
         // 引数省略すると updatedAtが 降順（Desc）新しい日付から古い日付になる
         const sessions = await sessionService.getAll();
-        expect(sessions.length).toBe(teachers.reduce((acc, teacher) => acc + teacher.sessions.length, 0));
+        
         expect(sessions).toEqual([...sessions].sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime()));
       }
     );
@@ -359,10 +367,11 @@ describe("教員のLS作成と取得、学生のLS参加と取得のテスト", 
     it("成功する", async () => {
       const teacher = teachers[0];
       // 引数省略すると updatedAtが 降順（Desc）新しい日付から古い日付になる
-      const sessions = await sessionService.getAllByTeacherId(teacher.id!,sessionWithEnrollmentsSchema);
+      const sessions = await sessionService.getAllByTeacherId(teacher.id!,forGetAllByTeacherIdSchema);
       expect(sessions.length).toBe(teacher.sessions.length);
       expect(sessions).toEqual([...sessions].sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime()));
       sessions.forEach((session) => {
+        expect(session.questions.length).toEqual(1); // 1つの質問が登録されている
         expect(session.enrollments.length).toEqual(2); //「構文 誤次郎」と「仕様 曖昧子」
       });
     });

--- a/src/__tests__/integration01.test.ts
+++ b/src/__tests__/integration01.test.ts
@@ -154,7 +154,7 @@ describe("教員のLS作成と取得、学生のLS参加と取得のテスト", 
       //prettier-ignore
       it("成功する", async () => {
         // 引数省略すると updatedAtが 降順（Desc）新しい日付から古い日付になる
-        const sessions = await sessionService.getAll();
+        const {sessions}  = await sessionService.getAll();
         
         expect(sessions).toEqual([...sessions].sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime()));
       }
@@ -164,7 +164,7 @@ describe("教員のLS作成と取得、学生のLS参加と取得のテスト", 
     describe("全てのLSの一覧（日付 asc [旧]→[新] の順番）の取得", () => {
       //prettier-ignore
       it("成功する", async () => {
-        const sessions = await sessionService.getAll(undefined,"updatedAt", "asc");
+        const {sessions} = await sessionService.getAll(undefined,"updatedAt", "asc");
         expect(sessions).toEqual([...sessions].sort((a, b) => a.updatedAt.getTime() - b.updatedAt.getTime()));
       }
     );
@@ -173,7 +173,7 @@ describe("教員のLS作成と取得、学生のLS参加と取得のテスト", 
     describe("全てのLSの一覧（タイトル昇順）の取得", () => {
       //prettier-ignore
       it("成功する", async () => {
-        const sessions = await sessionService.getAll(undefined,"title", "asc"); 
+        const { sessions } = await sessionService.getAll(undefined,"title", "asc"); 
         expect(sessions).toEqual([...sessions].sort((a, b) => a.title.localeCompare(b.title)));
       }
     );
@@ -182,7 +182,7 @@ describe("教員のLS作成と取得、学生のLS参加と取得のテスト", 
     describe("全てのLSの一覧（タイトル降順）の取得", () => {
       //prettier-ignore
       it("成功する", async () => {
-        const sessions = await sessionService.getAll(undefined,"title", "desc"); 
+        const {sessions} = await sessionService.getAll(undefined,"title", "desc"); 
         expect(sessions).toEqual([...sessions].sort((a, b) => b.title.localeCompare(a.title)));
       }
     );
@@ -235,6 +235,7 @@ describe("教員のLS作成と取得、学生のLS参加と取得のテスト", 
 
         // StudentId をキーにセッションを取得
         const sessions = await sessionService.getAllByStudentId(student.id!);
+        console.log(JSON.stringify(sessions, null, 2));
         const actualIdSet1 = new Set<string>(
           sessions.map((session) => session.id!)
         );
@@ -371,8 +372,10 @@ describe("教員のLS作成と取得、学生のLS参加と取得のテスト", 
       expect(sessions.length).toBe(teacher.sessions.length);
       expect(sessions).toEqual([...sessions].sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime()));
       sessions.forEach((session) => {
-        expect(session.questions.length).toEqual(1); // 1つの質問が登録されている
-        expect(session.enrollments.length).toEqual(2); //「構文 誤次郎」と「仕様 曖昧子」
+        // @ts-ignore 型推論に失敗するが.questionsは存在
+        expect(session._count.questions).toEqual(1); // 1つの質問が登録されている
+        // @ts-ignore 型推論に失敗するが.enrollmentsは存在
+        expect(session._count.enrollments).toEqual(2); //「構文 誤次郎」と「仕様 曖昧子」
       });
     });
   });

--- a/src/app/_components/elements/ActionButton.tsx
+++ b/src/app/_components/elements/ActionButton.tsx
@@ -16,6 +16,7 @@ const button = tv({
     width: {
       auto: "",
       stretch: "w-full",
+      slim: "px-3 py-1",
     },
     disabled: {
       true: "cursor-not-allowed opacity-50",

--- a/src/app/_components/shadcn/ui/dialog.tsx
+++ b/src/app/_components/shadcn/ui/dialog.tsx
@@ -1,0 +1,122 @@
+"use client"
+
+import * as React from "react"
+import * as DialogPrimitive from "@radix-ui/react-dialog"
+import { X } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+const Dialog = DialogPrimitive.Root
+
+const DialogTrigger = DialogPrimitive.Trigger
+
+const DialogPortal = DialogPrimitive.Portal
+
+const DialogClose = DialogPrimitive.Close
+
+const DialogOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn(
+      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className
+    )}
+    {...props}
+  />
+))
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName
+
+const DialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border border-slate-200 bg-white p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg dark:border-slate-800 dark:bg-slate-950",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-white transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-slate-950 focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-slate-100 data-[state=open]:text-slate-500 dark:ring-offset-slate-950 dark:focus:ring-slate-300 dark:data-[state=open]:bg-slate-800 dark:data-[state=open]:text-slate-400">
+        <X className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+  </DialogPortal>
+))
+DialogContent.displayName = DialogPrimitive.Content.displayName
+
+const DialogHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col space-y-1.5 text-center sm:text-left",
+      className
+    )}
+    {...props}
+  />
+)
+DialogHeader.displayName = "DialogHeader"
+
+const DialogFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+      className
+    )}
+    {...props}
+  />
+)
+DialogFooter.displayName = "DialogFooter"
+
+const DialogTitle = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn(
+      "text-lg font-semibold leading-none tracking-tight",
+      className
+    )}
+    {...props}
+  />
+))
+DialogTitle.displayName = DialogPrimitive.Title.displayName
+
+const DialogDescription = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-slate-500 dark:text-slate-400", className)}
+    {...props}
+  />
+))
+DialogDescription.displayName = DialogPrimitive.Description.displayName
+
+export {
+  Dialog,
+  DialogPortal,
+  DialogOverlay,
+  DialogClose,
+  DialogTrigger,
+  DialogContent,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+}

--- a/src/app/_components/shadcn/ui/label.tsx
+++ b/src/app/_components/shadcn/ui/label.tsx
@@ -1,0 +1,26 @@
+"use client"
+
+import * as React from "react"
+import * as LabelPrimitive from "@radix-ui/react-label"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const labelVariants = cva(
+  "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+)
+
+const Label = React.forwardRef<
+  React.ElementRef<typeof LabelPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root> &
+    VariantProps<typeof labelVariants>
+>(({ className, ...props }, ref) => (
+  <LabelPrimitive.Root
+    ref={ref}
+    className={cn(labelVariants(), className)}
+    {...props}
+  />
+))
+Label.displayName = LabelPrimitive.Root.displayName
+
+export { Label }

--- a/src/app/_services/sessionService.ts
+++ b/src/app/_services/sessionService.ts
@@ -5,6 +5,7 @@ import {
   withErrorHandling,
 } from "@/app/_services/servicesExceptions";
 import QuestionService from "@/app/_services/questionService";
+import { type UpdateSessionRequest } from "@/app/_types/SessionTypes";
 
 ///////////////////////////////////////////////////////////////
 
@@ -26,9 +27,22 @@ export const fullSessionSchema = {
   },
 } as const;
 
-export const sessionWithEnrollmentsSchema = {
+export const forGetAllByTeacherIdSchema = {
   include: {
     enrollments: true,
+    questions: true,
+  },
+} as const;
+
+export const forGetAllByStudentIdSchema = {
+  include: {
+    enrollments: true,
+    questions: true,
+    teacher: {
+      include: {
+        user: true,
+      },
+    },
   },
 } as const;
 
@@ -162,7 +176,23 @@ class SessionService {
     })) as PRS.LearningSessionGetPayload<{ include: T; select: U }>[];
   }
 
-  // 名前（title属性）の変更
+  // 基本情報（title,isActive）の更新 セッションの存在は確認済みであること
+  @withErrorHandling()
+  public async update(
+    sessionId: string,
+    data: UpdateSessionRequest
+  ): Promise<void> {
+    await this.prisma.learningSession.update({
+      where: { id: sessionId },
+      data: { ...data },
+    });
+  }
+
+  /**
+   * 名前（title属性）の更新
+   * @deprecated Use update() instead.
+   * @see update
+   */
   @withErrorHandling()
   public async updateTitle(sessionId: string, title: string): Promise<void> {
     try {

--- a/src/app/_services/sessionService.ts
+++ b/src/app/_services/sessionService.ts
@@ -142,7 +142,7 @@ class SessionService {
   >(
     teacherId: string,
     options?: SessionReturnType<T, U>,
-    sortKey: "updatedAt" | "title" = "updatedAt",
+    sortKey: "updatedAt" | "createdAt" | "title" = "updatedAt",
     sortDirection: "asc" | "desc" = "desc"
   ): Promise<PRS.LearningSessionGetPayload<{ include: T; select: U }>[]> {
     return (await this.prisma.learningSession.findMany({
@@ -160,7 +160,7 @@ class SessionService {
   >(
     studentId: string,
     options?: SessionReturnType<T, U>,
-    sortKey: "updatedAt" | "title" = "updatedAt",
+    sortKey: "updatedAt" | "createdAt" | "title" = "updatedAt",
     sortDirection: "asc" | "desc" = "desc"
   ): Promise<PRS.LearningSessionGetPayload<{ include: T; select: U }>[]> {
     return (await this.prisma.learningSession.findMany({

--- a/src/app/_types/SessionTypes.ts
+++ b/src/app/_types/SessionTypes.ts
@@ -15,11 +15,11 @@ export const isCUID = (value: string) => /^c[a-z0-9]{24}$/.test(value);
 export interface SessionSummary {
   id: string;
   title: string;
-  teacherName: string;
+  teacherName: string; // *
   accessCode: string;
   isActive: boolean;
-  enrollmentCount: number;
-  questionsCount: number;
+  enrollmentCount: number; // *
+  questionsCount: number; // *
   updatedAt: Date;
   createdAt: Date;
 }

--- a/src/app/_types/SessionTypes.ts
+++ b/src/app/_types/SessionTypes.ts
@@ -8,6 +8,7 @@ import { z } from "zod";
 
 const requiredMsg = "必須入力の項目です。";
 export const AccessCodePattern = /^\d{3}-\d{4}$/;
+export const isCUID = (value: string) => /^c[a-z0-9]{24}$/.test(value);
 
 ///////////////////////////////////////////////////////////////
 
@@ -18,7 +19,9 @@ export interface SessionSummary {
   accessCode: string;
   isActive: boolean;
   enrollmentCount: number;
+  questionsCount: number;
   updatedAt: Date;
+  createdAt: Date;
 }
 
 ///////////////////////////////////////////////////////////////
@@ -33,8 +36,33 @@ export const createSessionRequestSchema = z.object({
     .min(1, requiredMsg)
     .max(30, "30文字以内で入力してください。")
     .transform((v) => v.trim())
-    .refine((val) => val.length >= 1, {
+    .refine((v) => v.length >= 3, {
       message:
-        "必須入力項目です。前後の空白文字を除いて 1文字以上 を入力してください。",
+        "必須入力項目です。前後の空白文字を除いて 3文字以上 を入力してください。",
     }),
+});
+
+///////////////////////////////////////////////////////////////
+
+export interface UpdateSessionRequest {
+  id: string;
+  title?: string;
+  isActive?: boolean;
+}
+
+export const updateSessionRequestSchema = z.object({
+  id: z.string().refine(isCUID, {
+    message: "Invalid CUID format.",
+  }),
+  title: z
+    .string()
+    .min(1, requiredMsg)
+    .max(30, "30文字以内で入力してください。")
+    .transform((v) => v.trim())
+    .refine((v) => v.length >= 3, {
+      message:
+        "必須入力項目です。前後の空白文字を除いて 3文字以上 を入力してください。",
+    })
+    .optional(),
+  isActive: z.boolean().optional(),
 });

--- a/src/app/_types/UserTypes.ts
+++ b/src/app/_types/UserTypes.ts
@@ -63,10 +63,7 @@ export interface UserProfile {
 }
 
 export const userProfileSchema = z.object({
-  id: z
-    .string()
-    .regex(uuidRegex, "不正な形式です。Invalid UUID format.")
-    .optional(),
+  id: z.string().regex(uuidRegex, "Invalid UUID format.").optional(),
   role: z.enum([Role.ADMIN, Role.TEACHER, Role.STUDENT]).optional(),
   displayName: z
     .string()

--- a/src/app/_utils/createApiRequest.ts
+++ b/src/app/_utils/createApiRequest.ts
@@ -1,0 +1,95 @@
+import axios, { AxiosError, AxiosResponse, Method } from "axios";
+import { isDevelopmentEnv, apiDelay } from "@/config/app-config";
+import ApiRequestHeader from "@/app/_types/ApiRequestHeader";
+import { ApiErrorResponse, Origin } from "@/app/_types/ApiResponse";
+import AppErrorCode from "@/app/_types/AppErrorCode";
+
+type HttpMethod = "get" | "post" | "put" | "delete";
+
+const createRequest = <RequestBody = any, Response = any>(
+  method: HttpMethod
+) => {
+  return async (
+    url: string,
+    dataOrHeaders?: RequestBody | ApiRequestHeader,
+    headers?: ApiRequestHeader
+  ): Promise<Response | ApiErrorResponse> => {
+    let data: RequestBody | undefined;
+    let requestHeaders: ApiRequestHeader | undefined;
+
+    if (method === "get" || method === "delete") {
+      requestHeaders = dataOrHeaders as ApiRequestHeader;
+    } else {
+      data = dataOrHeaders as RequestBody;
+      requestHeaders = headers;
+    }
+
+    const isAuthHeaderValid =
+      requestHeaders === undefined || requestHeaders?.Authorization != null;
+
+    if (!isAuthHeaderValid) {
+      const errorResponse: ApiErrorResponse = {
+        success: false,
+        data: null,
+        error: {
+          origin: Origin.CLIENT,
+          appErrorCode: AppErrorCode.INVALID_HTTP_HEADER,
+          technicalInfo:
+            "引数 headers に { Authorization : null } が含まれるため意図的に通信を遮断しました。useAuthが初期中の可能性があります。",
+          technicalInfoObject: { headers: requestHeaders },
+        },
+        httpStatus: 400,
+      };
+      return errorResponse;
+    }
+
+    const options = {
+      method: method as Method,
+      url,
+      headers: requestHeaders,
+      ...(method !== "get" && method !== "delete" && { data }),
+    };
+
+    try {
+      const res: AxiosResponse<Response> = await axios(options);
+
+      // 開発環境では、動作検証のためにDelayを設定
+      if (isDevelopmentEnv && apiDelay > 0) {
+        await new Promise((resolve) => setTimeout(resolve, apiDelay));
+      }
+
+      return res.data;
+    } catch (error) {
+      if (error instanceof AxiosError) {
+        // バックエンドからの情報ある場合
+        if (error?.response?.data) {
+          return error.response.data;
+        }
+
+        // バックエンドからの情報がない場合
+        const errorResponse: ApiErrorResponse = {
+          success: false,
+          data: null,
+          error: {
+            origin: Origin.CLIENT,
+            appErrorCode: AppErrorCode.AXIOS_ERROR,
+            technicalInfo: error.message,
+            technicalInfoObject: error,
+          },
+          httpStatus: error.response?.status || 400,
+        };
+        return errorResponse;
+      }
+      throw error;
+    }
+  };
+};
+
+export const createGetRequest = <Response>() =>
+  createRequest<never, Response>("get");
+export const createPostRequest = <RequestBody, Response>() =>
+  createRequest<RequestBody, Response>("post");
+export const createPutRequest = <RequestBody, Response>() =>
+  createRequest<RequestBody, Response>("put");
+export const createDeleteRequest = <Response>() =>
+  createRequest<never, Response>("delete");

--- a/src/app/_utils/createDeleteRequest.ts
+++ b/src/app/_utils/createDeleteRequest.ts
@@ -1,0 +1,69 @@
+import axios, { AxiosError, AxiosResponse } from "axios";
+import { isDevelopmentEnv, apiDelay } from "@/config/app-config";
+import ApiRequestHeader from "@/app/_types/ApiRequestHeader";
+import { ApiErrorResponse, Origin } from "@/app/_types/ApiResponse";
+import AppErrorCode from "@/app/_types/AppErrorCode";
+
+const createDeleteRequest = <RequestBody, Response>() => {
+  return async (
+    url: string,
+    headers?: ApiRequestHeader
+  ): Promise<Response | ApiErrorResponse> => {
+    // useAuth が初期化中である場合に備えた処理
+    // isAuthHeaderValid が true になるのは、headers が undefined か、
+    // headers.Authorization が null や undefined でない場合
+    const isAuthHeaderValid =
+      headers === undefined || headers?.Authorization != null;
+    if (!isAuthHeaderValid) {
+      const errorResponse: ApiErrorResponse = {
+        success: false,
+        data: null,
+        error: {
+          origin: Origin.CLIENT,
+          appErrorCode: AppErrorCode.INVALID_HTTP_HEADER,
+          technicalInfo:
+            "引数 headers に { Authorization : null } が含まれるため意図的に通信を遮断しました。useAuthが初期中の可能性があります。",
+          technicalInfoObject: { headers },
+        },
+        httpStatus: 400,
+      };
+      return errorResponse;
+    }
+
+    const options = headers ? { headers } : {};
+    let res: AxiosResponse<Response, any> | null = null;
+    try {
+      res = await axios.delete<Response>(url, options);
+      res = res as AxiosResponse<Response, any>;
+      // 開発環境では、動作検証のためにDelayを設定
+      if (isDevelopmentEnv && apiDelay > 0) {
+        await new Promise((resolve) => setTimeout(resolve, apiDelay));
+      }
+      return res.data;
+    } catch (error) {
+      if (error instanceof AxiosError) {
+        // バックエンドからの情報ある場合
+        if (error?.response?.data) {
+          return error.response.data;
+        }
+
+        // バックエンドからの情報がない場合
+        const errorResponse: ApiErrorResponse = {
+          success: false,
+          data: null,
+          error: {
+            origin: Origin.CLIENT,
+            appErrorCode: AppErrorCode.AXIOS_ERROR,
+            technicalInfo: error.message,
+            technicalInfoObject: error,
+          },
+          httpStatus: error.response?.status || 400,
+        };
+        return errorResponse;
+      }
+      throw error;
+    }
+  };
+};
+
+export default createDeleteRequest;

--- a/src/app/_utils/createPutRequest.ts
+++ b/src/app/_utils/createPutRequest.ts
@@ -1,0 +1,70 @@
+import axios, { AxiosError, AxiosResponse } from "axios";
+import { isDevelopmentEnv, apiDelay } from "@/config/app-config";
+import ApiRequestHeader from "@/app/_types/ApiRequestHeader";
+import { ApiErrorResponse, Origin } from "@/app/_types/ApiResponse";
+import AppErrorCode from "@/app/_types/AppErrorCode";
+
+const createPutRequest = <RequestBody, Response>() => {
+  return async (
+    url: string,
+    data: RequestBody,
+    headers?: ApiRequestHeader
+  ): Promise<Response | ApiErrorResponse> => {
+    // useAuth が初期化中である場合に備えた処理
+    // isAuthHeaderValid が true になるのは、headers が undefined か、
+    // headers.Authorization が null や undefined でない場合
+    const isAuthHeaderValid =
+      headers === undefined || headers?.Authorization != null;
+    if (!isAuthHeaderValid) {
+      const errorResponse: ApiErrorResponse = {
+        success: false,
+        data: null,
+        error: {
+          origin: Origin.CLIENT,
+          appErrorCode: AppErrorCode.INVALID_HTTP_HEADER,
+          technicalInfo:
+            "引数 headers に { Authorization : null } が含まれるため意図的に通信を遮断しました。useAuthが初期中の可能性があります。",
+          technicalInfoObject: { headers },
+        },
+        httpStatus: 400,
+      };
+      return errorResponse;
+    }
+
+    const options = headers ? { headers } : {};
+    let res: AxiosResponse<Response, any> | null = null;
+    try {
+      res = await axios.put<Response>(url, data, options);
+      res = res as AxiosResponse<Response, any>;
+      // 開発環境では、動作検証のためにDelayを設定
+      if (isDevelopmentEnv && apiDelay > 0) {
+        await new Promise((resolve) => setTimeout(resolve, apiDelay));
+      }
+      return res.data;
+    } catch (error) {
+      if (error instanceof AxiosError) {
+        // バックエンドからの情報ある場合
+        if (error?.response?.data) {
+          return error.response.data;
+        }
+
+        // バックエンドからの情報がない場合
+        const errorResponse: ApiErrorResponse = {
+          success: false,
+          data: null,
+          error: {
+            origin: Origin.CLIENT,
+            appErrorCode: AppErrorCode.AXIOS_ERROR,
+            technicalInfo: error.message,
+            technicalInfoObject: error,
+          },
+          httpStatus: error.response?.status || 400,
+        };
+        return errorResponse;
+      }
+      throw error;
+    }
+  };
+};
+
+export default createPutRequest;

--- a/src/app/_utils/datetime2str.ts
+++ b/src/app/_utils/datetime2str.ts
@@ -1,0 +1,14 @@
+import dayjs from "dayjs";
+import utc from "dayjs/plugin/utc";
+import timezone from "dayjs/plugin/timezone";
+dayjs.locale("ja");
+dayjs.extend(utc);
+dayjs.extend(timezone);
+
+const datetime2str = (datetime: Date, format?: string) => {
+  return dayjs(datetime)
+    .tz("Asia/Tokyo")
+    .format(format || "YYYY/MM/DD HH:mm:ss");
+};
+
+export default datetime2str;

--- a/src/app/api/v1/admin/assign-role/route.ts
+++ b/src/app/api/v1/admin/assign-role/route.ts
@@ -22,7 +22,7 @@ import { z } from "zod";
 
 export const revalidate = 0; // キャッシュを無効化
 
-// [POST] /api/v1/user/assign-role
+// [POST] /api/v1/admin/assign-role
 export const POST = async (req: NextRequest) => {
   const userService = new UserService(prisma);
   let postBody: any;

--- a/src/app/api/v1/student/sessions/route.ts
+++ b/src/app/api/v1/student/sessions/route.ts
@@ -1,0 +1,78 @@
+// APIリクエスト・レスポンス関係
+import { NextResponse, NextRequest } from "next/server";
+import { ApiErrorResponse } from "@/app/_types/ApiResponse";
+import SuccessResponseBuilder from "@/app/api/_helpers/successResponseBuilder";
+import ErrorResponseBuilder from "@/app/api/_helpers/errorResponseBuilder";
+import { StatusCodes } from "@/app/_utils/extendedStatusCodes";
+import {
+  ApiError,
+  ZodValidationError,
+  NonTeacherOperationError,
+} from "@/app/api/_helpers/apiExceptions";
+
+// ユーザ認証・サービスクラス関係
+import prisma from "@/lib/prisma";
+import { getAuthUser } from "@/app/api/_helpers/getAuthUser";
+import UserService from "@/app/_services/userService";
+import SessionService, {
+  forGetAllByStudentIdSchema,
+} from "@/app/_services/sessionService";
+import { Prisma as PRS } from "@prisma/client";
+
+// 型定義・データ検証関連
+import { UserProfile, Role } from "@/app/_types/UserTypes";
+import { getAvatarImgUrl } from "@/app/api/_helpers/getAvatarImgUrl";
+import { SessionSummary } from "@/app/_types/SessionTypes";
+
+export const revalidate = 0; // キャッシュを無効化
+
+// [GET] /api/v1/student/sessions/
+// ユーザーが [学生] として作成したセッションの一覧を取得
+export const GET = async (req: NextRequest) => {
+  const userService = new UserService(prisma);
+  const sessionService = new SessionService(prisma);
+
+  try {
+    // トークンが不正なときは InvalidTokenError がスローされる
+    const authUser = await getAuthUser(req);
+
+    // ユーザが存在しない場合は UserService.NotFoundError がスローされる
+    const appUser = await userService.getById(authUser.id);
+
+    // レスポンスデータの作成
+    const sessions = (await sessionService.getAllByStudentId(
+      appUser.id,
+      forGetAllByStudentIdSchema
+    )) as PRS.LearningSessionGetPayload<typeof forGetAllByStudentIdSchema>[];
+
+    const res: SessionSummary[] = sessions.map((s) => {
+      return {
+        id: s.id,
+        title: s.title,
+        teacherName: s.teacher.user.displayName,
+        accessCode: s.accessCode,
+        isActive: s.isActive,
+        updatedAt: s.updatedAt,
+        enrollmentCount: s.enrollments.length,
+        questionsCount: s.questions.length,
+      };
+    });
+
+    return NextResponse.json(
+      new SuccessResponseBuilder<SessionSummary[]>(res)
+        .setHttpStatus(StatusCodes.OK)
+        .build()
+    );
+  } catch (error: any) {
+    const payload = createErrorResponse(error);
+    return NextResponse.json(payload, { status: payload.httpStatus });
+  }
+};
+
+// 失敗時のレスポンスを生成
+const createErrorResponse = (error: unknown): ApiErrorResponse => {
+  if (error instanceof ApiError) {
+    return new ErrorResponseBuilder(error).build();
+  }
+  return new ErrorResponseBuilder().setUnknownError(error).build();
+};

--- a/src/app/api/v1/student/sessions/route.ts
+++ b/src/app/api/v1/student/sessions/route.ts
@@ -53,6 +53,7 @@ export const GET = async (req: NextRequest) => {
         accessCode: s.accessCode,
         isActive: s.isActive,
         updatedAt: s.updatedAt,
+        createdAt: s.createdAt,
         enrollmentCount: s.enrollments.length,
         questionsCount: s.questions.length,
       };

--- a/src/app/api/v1/student/sessions/route.ts
+++ b/src/app/api/v1/student/sessions/route.ts
@@ -4,11 +4,7 @@ import { ApiErrorResponse } from "@/app/_types/ApiResponse";
 import SuccessResponseBuilder from "@/app/api/_helpers/successResponseBuilder";
 import ErrorResponseBuilder from "@/app/api/_helpers/errorResponseBuilder";
 import { StatusCodes } from "@/app/_utils/extendedStatusCodes";
-import {
-  ApiError,
-  ZodValidationError,
-  NonTeacherOperationError,
-} from "@/app/api/_helpers/apiExceptions";
+import { ApiError } from "@/app/api/_helpers/apiExceptions";
 
 // ユーザ認証・サービスクラス関係
 import prisma from "@/lib/prisma";
@@ -20,8 +16,6 @@ import SessionService, {
 import { Prisma as PRS } from "@prisma/client";
 
 // 型定義・データ検証関連
-import { UserProfile, Role } from "@/app/_types/UserTypes";
-import { getAvatarImgUrl } from "@/app/api/_helpers/getAvatarImgUrl";
 import { SessionSummary } from "@/app/_types/SessionTypes";
 
 export const revalidate = 0; // キャッシュを無効化
@@ -45,17 +39,16 @@ export const GET = async (req: NextRequest) => {
       forGetAllByStudentIdSchema
     )) as PRS.LearningSessionGetPayload<typeof forGetAllByStudentIdSchema>[];
 
-    const res: SessionSummary[] = sessions.map((s) => {
+    const res: SessionSummary[] = sessions.map((session) => {
       return {
-        id: s.id,
-        title: s.title,
-        teacherName: s.teacher.user.displayName,
-        accessCode: s.accessCode,
-        isActive: s.isActive,
-        updatedAt: s.updatedAt,
-        createdAt: s.createdAt,
-        enrollmentCount: s.enrollments.length,
-        questionsCount: s.questions.length,
+        ...session,
+        _count: undefined,
+        teacher: undefined,
+        teacherName: session.teacher.user.displayName,
+        // @ts-ignore 型推論に失敗するが.enrollmentsは存在
+        enrollmentCount: session._count.enrollments,
+        // @ts-ignore 型推論に失敗するが.enrollmentsは存在
+        questionsCount: session._count.questions,
       };
     });
 

--- a/src/app/api/v1/teacher/sessions/[id]/route.ts
+++ b/src/app/api/v1/teacher/sessions/[id]/route.ts
@@ -1,0 +1,125 @@
+// APIリクエスト・レスポンス関係
+import { NextResponse, NextRequest } from "next/server";
+import { ApiErrorResponse } from "@/app/_types/ApiResponse";
+import SuccessResponseBuilder from "@/app/api/_helpers/successResponseBuilder";
+import ErrorResponseBuilder from "@/app/api/_helpers/errorResponseBuilder";
+import { StatusCodes } from "@/app/_utils/extendedStatusCodes";
+import {
+  ApiError,
+  NonTeacherOperationError,
+} from "@/app/api/_helpers/apiExceptions";
+
+// ユーザ認証・サービスクラス関係
+import prisma from "@/lib/prisma";
+import { getAuthUser } from "@/app/api/_helpers/getAuthUser";
+import UserService from "@/app/_services/userService";
+import SessionService from "@/app/_services/sessionService";
+
+// 型定義・データ検証関連
+import { Role } from "@/app/_types/UserTypes";
+import { DomainRuleViolationError } from "@/app/_services/servicesExceptions";
+import {
+  UpdateSessionRequest,
+  updateSessionRequestSchema,
+} from "@/app/_types/SessionTypes";
+
+export const revalidate = 0; // キャッシュを無効化
+
+type Params = { params: { id: string } };
+
+// [PUT] /api/v1/teacher/sessions/[id] 指定IDのセッション情報を更新
+export const PUT = async (req: NextRequest, { params: { id } }: Params) => {
+  const userService = new UserService(prisma);
+  const sessionService = new SessionService(prisma);
+  const sessionId = id;
+  let reqBody: any;
+
+  try {
+    // トークンが不正なときは InvalidTokenError がスローされる
+    const authUser = await getAuthUser(req);
+
+    // ユーザが存在しない場合は UserService.NotFoundError がスローされる
+    const appUser = await userService.getById(authUser.id);
+
+    // ユーザーが 教員 または 管理者 のロールを持たない場合は Error がスローされる
+    if (appUser.role === Role.STUDENT) {
+      throw new NonTeacherOperationError(appUser.id, appUser.displayName);
+    }
+
+    // セッションが存在しない場合は Error がスローされる
+    const session = await sessionService.getById(sessionId);
+
+    // セッションが appUser の所有であるかを確認
+    if (session.teacherId !== appUser.id) {
+      throw new DomainRuleViolationError(
+        `${appUser.displayName} は、SessionID: ${sessionId} の削除権限を持ちません。`,
+        { userId: appUser.id, userDisplayName: appUser.displayName, sessionId }
+      );
+    }
+
+    // リクエストボディの検証
+    reqBody = await req.json();
+    const updateSessionRequest: UpdateSessionRequest =
+      updateSessionRequestSchema.parse(reqBody);
+    updateSessionRequest.title?.trim();
+
+    // 更新処理の実行
+    await sessionService.update(sessionId, updateSessionRequest);
+
+    return NextResponse.json(
+      new SuccessResponseBuilder(null).setHttpStatus(StatusCodes.OK).build()
+    );
+  } catch (error: any) {
+    const payload = createErrorResponse(error);
+    return NextResponse.json(payload, { status: payload.httpStatus });
+  }
+};
+
+// [DELETE] /api/v1/teacher/sessions/[id] 指定IDのセッションを削除
+export const DELETE = async (req: NextRequest, { params: { id } }: Params) => {
+  const userService = new UserService(prisma);
+  const sessionService = new SessionService(prisma);
+  const sessionId = id;
+
+  try {
+    // トークンが不正なときは InvalidTokenError がスローされる
+    const authUser = await getAuthUser(req);
+
+    // ユーザが存在しない場合は UserService.NotFoundError がスローされる
+    const appUser = await userService.getById(authUser.id);
+
+    // ユーザーが 教員 または 管理者 のロールを持たない場合は Error がスローされる
+    if (appUser.role === Role.STUDENT) {
+      throw new NonTeacherOperationError(appUser.id, appUser.displayName);
+    }
+
+    // セッションが存在しない場合は Error がスローされる
+    const session = await sessionService.getById(sessionId);
+
+    // セッションが appUser の所有であるかを確認
+    if (session.teacherId !== appUser.id) {
+      throw new DomainRuleViolationError(
+        `${appUser.displayName} は、SessionID: ${sessionId} の削除権限を持ちません。`,
+        { userId: appUser.id, userDisplayName: appUser.displayName, sessionId }
+      );
+    }
+
+    // 削除処理の実行
+    await sessionService.delete(sessionId);
+
+    return NextResponse.json(
+      new SuccessResponseBuilder(null).setHttpStatus(StatusCodes.OK).build()
+    );
+  } catch (error: any) {
+    const payload = createErrorResponse(error);
+    return NextResponse.json(payload, { status: payload.httpStatus });
+  }
+};
+
+// 失敗時のレスポンスを生成
+const createErrorResponse = (error: unknown): ApiErrorResponse => {
+  if (error instanceof ApiError) {
+    return new ErrorResponseBuilder(error).build();
+  }
+  return new ErrorResponseBuilder().setUnknownError(error).build();
+};

--- a/src/app/api/v1/teacher/sessions/new/route.ts
+++ b/src/app/api/v1/teacher/sessions/new/route.ts
@@ -1,0 +1,91 @@
+// APIリクエスト・レスポンス関係
+import { NextResponse, NextRequest } from "next/server";
+import { ApiErrorResponse } from "@/app/_types/ApiResponse";
+import SuccessResponseBuilder from "@/app/api/_helpers/successResponseBuilder";
+import ErrorResponseBuilder from "@/app/api/_helpers/errorResponseBuilder";
+import { StatusCodes } from "@/app/_utils/extendedStatusCodes";
+import {
+  ApiError,
+  ZodValidationError,
+  NonTeacherOperationError,
+} from "@/app/api/_helpers/apiExceptions";
+
+// ユーザ認証・サービスクラス関係
+import prisma from "@/lib/prisma";
+import { getAuthUser } from "@/app/api/_helpers/getAuthUser";
+import UserService from "@/app/_services/userService";
+import SessionService from "@/app/_services/sessionService";
+
+// 型定義・データ検証関連
+import { z } from "zod";
+import { Role } from "@/app/_types/UserTypes";
+import {
+  CreateSessionRequest,
+  createSessionRequestSchema,
+  SessionSummary,
+} from "@/app/_types/SessionTypes";
+
+export const revalidate = 0; // キャッシュを無効化
+
+// [POST] /api/v1/teacher/sessions/new　セッションの新規作成
+export const POST = async (req: NextRequest) => {
+  const userService = new UserService(prisma);
+  const sessionService = new SessionService(prisma);
+  let reqBody: any;
+
+  try {
+    // トークンが不正なときは InvalidTokenError がスローされる
+    const authUser = await getAuthUser(req);
+
+    // ユーザが存在しない場合は UserService.NotFoundError がスローされる
+    const appUser = await userService.getById(authUser.id);
+
+    // ユーザーが 教員 または 管理者 のロールを持たない場合は Error がスローされる
+    if (appUser.role === Role.STUDENT) {
+      throw new NonTeacherOperationError(appUser.id, appUser.displayName);
+    }
+
+    // リクエストボディの検証
+    reqBody = await req.json();
+    const createSessionRequest: CreateSessionRequest =
+      createSessionRequestSchema.parse(reqBody);
+    createSessionRequest.title = createSessionRequest.title.trim();
+
+    // ラーニングセッションの新規作成処理
+    const session = await sessionService.create(
+      appUser.id,
+      createSessionRequest.title
+    );
+
+    const res: SessionSummary = {
+      id: session.id,
+      title: session.title,
+      teacherName: appUser.displayName,
+      accessCode: session.accessCode,
+      isActive: session.isActive,
+      enrollmentCount: 0,
+      questionsCount: 1,
+      updatedAt: session.updatedAt,
+      createdAt: session.createdAt,
+    };
+
+    // レスポンス
+    return NextResponse.json(
+      new SuccessResponseBuilder(res).setHttpStatus(StatusCodes.CREATED).build()
+    );
+  } catch (error: any) {
+    if (error instanceof z.ZodError) {
+      error = new ZodValidationError(error.message, reqBody);
+    }
+    const payload = createErrorResponse(error);
+    return NextResponse.json(payload, { status: payload.httpStatus });
+  }
+};
+
+// 失敗時のレスポンスを生成
+const createErrorResponse = (error: unknown): ApiErrorResponse => {
+  if (error instanceof ApiError) {
+    return new ErrorResponseBuilder(error).build();
+  }
+  return new ErrorResponseBuilder().setUnknownError(error).build();
+};

--- a/src/app/api/v1/teacher/sessions/route.ts
+++ b/src/app/api/v1/teacher/sessions/route.ts
@@ -46,7 +46,8 @@ export const GET = async (req: NextRequest) => {
     // レスポンスデータの作成
     const sessions = await sessionService.getAllByTeacherId(
       appUser.id,
-      forGetAllByTeacherIdSchema
+      forGetAllByTeacherIdSchema,
+      "createdAt"
     );
     const res: SessionSummary[] = sessions.map((s) => {
       return {

--- a/src/app/api/v1/teacher/sessions/route.ts
+++ b/src/app/api/v1/teacher/sessions/route.ts
@@ -49,19 +49,15 @@ export const GET = async (req: NextRequest) => {
       forGetAllByTeacherIdSchema,
       "createdAt"
     );
-    const res: SessionSummary[] = sessions.map((s) => {
-      return {
-        id: s.id,
-        title: s.title,
-        teacherName: appUser.displayName,
-        accessCode: s.accessCode,
-        isActive: s.isActive,
-        updatedAt: s.updatedAt,
-        createdAt: s.createdAt,
-        enrollmentCount: s.enrollments.length,
-        questionsCount: s.questions.length,
-      };
-    });
+    const res: SessionSummary[] = sessions.map((session) => ({
+      ...session,
+      _count: undefined,
+      teacherName: appUser.displayName,
+      // @ts-ignore 型推論に失敗するが.enrollmentsは存在
+      enrollmentCount: session._count.enrollments,
+      // @ts-ignore 型推論に失敗するが.enrollmentsは存在
+      questionsCount: session._count.questions,
+    }));
 
     return NextResponse.json(
       new SuccessResponseBuilder<SessionSummary[]>(res)

--- a/src/app/teacher/page.tsx
+++ b/src/app/teacher/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+
 import React from "react";
 import Link from "@/app/_components/elements/Link";
 import PageTitle from "@/app/_components/elements/PageTitle";

--- a/src/app/teacher/sessions/[code]/page.tsx
+++ b/src/app/teacher/sessions/[code]/page.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import React from "react";
+import { useParams } from "next/navigation";
+import PageTitle from "@/app/_components/elements/PageTitle";
+
+const Page: React.FC = () => {
+  const { code } = useParams<{ code: string }>();
+  return (
+    <div>
+      <PageTitle title={`AccessCode: ${code}`} />
+      <div>未実装</div>
+    </div>
+  );
+};
+
+export default Page;

--- a/src/app/teacher/sessions/_components/BeginnersGuide.tsx
+++ b/src/app/teacher/sessions/_components/BeginnersGuide.tsx
@@ -1,0 +1,110 @@
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import {
+  faChalkboardUser,
+  faGraduationCap,
+  faEllipsisVertical,
+  faCommentDots,
+} from "@fortawesome/free-solid-svg-icons";
+
+const BeginnersGuide: React.FC = () => {
+  return (
+    <div className="space-y-6">
+      <div className="space-y-2 break-words text-justify">
+        <p className="indent-paragraph text-slate-500">
+          Microsoft Forms や Google Forms では、
+          設問群を管理する単位を「フォーム」と呼びますが、
+          プログレスレンズでは、これを「<strong>ラーニングセッション</strong>
+          」と呼びます。
+          通常、授業1回ごとに個別のラーニングセッションを作成して活用します。
+        </p>
+      </div>
+
+      <div className="flex w-full flex-col gap-x-4 gap-y-3 px-5 md:flex-row md:items-start">
+        <div className="w-full md:w-1/2">
+          <div className="text-sm font-bold text-orange-400">
+            <FontAwesomeIcon icon={faChalkboardUser} className="mr-1" />
+            ラーニングセッション
+          </div>
+          <div className="mt-0.5 rounded-md bg-orange-400 px-3 py-2">
+            <div className=" text-white">
+              <div className="">
+                <FontAwesomeIcon icon={faGraduationCap} className="mr-2" />
+                第03回 プログラミング基礎演習
+              </div>
+              <ul className="ml-2 mt-1 text-sm">
+                <li>
+                  <FontAwesomeIcon
+                    icon={faCommentDots}
+                    flip="horizontal"
+                    className="mr-2"
+                  />
+                  演習1の進捗状況は?
+                </li>
+                <li>
+                  <FontAwesomeIcon
+                    icon={faCommentDots}
+                    flip="horizontal"
+                    className="mr-2"
+                  />
+                  演習2の進捗状況は?
+                </li>
+                <li>
+                  <FontAwesomeIcon
+                    icon={faCommentDots}
+                    flip="horizontal"
+                    className="mr-2"
+                  />
+                  演習3の進捗状況は?
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+        <div className="w-full md:w-1/2">
+          <div className="text-sm font-bold text-orange-400">
+            <FontAwesomeIcon icon={faChalkboardUser} className="mr-1" />
+            ラーニングセッション
+          </div>
+          <div className="mt-0.5 rounded-md bg-orange-400 px-3 py-2">
+            <div className="text-white">
+              <div className="">
+                <FontAwesomeIcon icon={faGraduationCap} className="mr-2" />
+                第06回 データベース工学
+              </div>
+              <ul className="ml-2 mt-1 text-sm">
+                <li>
+                  <FontAwesomeIcon
+                    icon={faCommentDots}
+                    flip="horizontal"
+                    className="mr-2"
+                  />
+                  第2正規形の現在の理解度は?
+                </li>
+                <li>
+                  <FontAwesomeIcon
+                    icon={faCommentDots}
+                    flip="horizontal"
+                    className="mr-2"
+                  />
+                  第3正規形の現在の理解度は?
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="space-y-2 break-words text-justify">
+        <p className="indent-paragraph">
+          ラーニングセッションを作成するためには、右上の「
+          <strong>新規作成</strong>」のボタンを押下するか、
+          既存のラーニングセッションの右端の
+          <FontAwesomeIcon icon={faEllipsisVertical} className="mx-2" />
+          をクリックして「<strong>複製</strong>」の項目を選択します。
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default BeginnersGuide;

--- a/src/app/teacher/sessions/_components/SessionTable.tsx
+++ b/src/app/teacher/sessions/_components/SessionTable.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+import React, { useState } from "react";
+import { twMerge } from "tailwind-merge";
+import { Input } from "@/app/_components/shadcn/ui/input";
+import { Button } from "@/app/_components/shadcn/ui/button";
+
+import {
+  ColumnDef,
+  SortingState,
+  ColumnFiltersState,
+  flexRender,
+  getCoreRowModel,
+  getFilteredRowModel,
+  getSortedRowModel,
+  getPaginationRowModel,
+  useReactTable,
+} from "@tanstack/react-table";
+
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/app/_components/shadcn/ui/table";
+
+interface Props<TData, TValue> {
+  columns: ColumnDef<TData, TValue>[];
+  data: TData[];
+}
+
+export const SessionTable = <TData, TValue>({
+  columns,
+  data,
+}: Props<TData, TValue>) => {
+  const [sorting, setSorting] = React.useState<SortingState>([]);
+
+  const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
+
+  const table = useReactTable({
+    data,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+    onColumnFiltersChange: setColumnFilters,
+    getFilteredRowModel: getFilteredRowModel(),
+    onSortingChange: setSorting,
+    getSortedRowModel: getSortedRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
+    state: {
+      sorting,
+      columnFilters,
+    },
+  });
+
+  return (
+    <div className="space-y-2">
+      {/* フィルタテキストボックス */}
+      <div className="flex items-center">
+        <Input
+          name="SessionTableFilter"
+          placeholder="Filter learning session names..."
+          value={(table.getColumn("title")?.getFilterValue() as string) ?? ""}
+          onChange={(event) =>
+            table.getColumn("title")?.setFilterValue(event.target.value)
+          }
+          className="max-w-sm"
+        />
+      </div>
+
+      {/* テーブル本体 */}
+      <div className="rounded-md border">
+        <Table>
+          <TableHeader>
+            {table.getHeaderGroups().map((headerGroup) => (
+              <TableRow key={headerGroup.id}>
+                {headerGroup.headers.map((header) => {
+                  const style = header.column.id === "title" ? "" : "px-0";
+                  return (
+                    <TableHead key={header.id} className={style}>
+                      {header.isPlaceholder
+                        ? null
+                        : flexRender(
+                            header.column.columnDef.header,
+                            header.getContext()
+                          )}
+                    </TableHead>
+                  );
+                })}
+              </TableRow>
+            ))}
+          </TableHeader>
+          <TableBody>
+            {table.getRowModel().rows?.length ? (
+              table.getRowModel().rows.map((row) => (
+                <TableRow
+                  key={row.id}
+                  data-state={row.getIsSelected() && "selected"}
+                >
+                  {row.getVisibleCells().map((cell) => {
+                    const style =
+                      cell.column.id === "title" ? "" : "px-0 sm:max-w-10";
+                    return (
+                      <TableCell
+                        key={cell.id}
+                        className={twMerge("py-2", style)}
+                      >
+                        {flexRender(
+                          cell.column.columnDef.cell,
+                          cell.getContext()
+                        )}
+                      </TableCell>
+                    );
+                  })}
+                </TableRow>
+              ))
+            ) : (
+              <TableRow>
+                <TableCell
+                  colSpan={columns.length}
+                  className="h-24 text-center"
+                >
+                  データが存在しません
+                  <br />
+                  [新規作成]のボタンからラーニングセッションを追加します
+                </TableCell>
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+      </div>
+
+      {/* ページネーション */}
+      <div className="flex items-center justify-end space-x-2">
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => table.previousPage()}
+          disabled={!table.getCanPreviousPage()}
+        >
+          Previous
+        </Button>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => table.nextPage()}
+          disabled={!table.getCanNextPage()}
+        >
+          Next
+        </Button>
+      </div>
+    </div>
+  );
+};

--- a/src/app/teacher/sessions/_components/TitleEditorDialog.tsx
+++ b/src/app/teacher/sessions/_components/TitleEditorDialog.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import React from "react";
+import { useFormContext } from "react-hook-form";
+
+// UIコンポーネント
+import TextInputField from "@/app/_components/elements/TextInputField";
+import ActionButton from "@/app/_components/elements/ActionButton";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/app/_components/shadcn/ui/dialog";
+import FormFieldErrorMsg from "@/app/_components/elements/FormFieldErrorMsg";
+
+// 型・定数・ユーティリティ
+import { createSessionRequestSchema } from "@/app/_types/SessionTypes";
+import { z } from "zod";
+
+export const editTitlePayloadSchema = createSessionRequestSchema.extend({
+  id: z.string().optional(),
+});
+
+export interface EditTitlePayload {
+  id?: string;
+  title: string;
+}
+
+interface Props {
+  dialogTitle: string;
+  submitButtonLabel: string;
+  isSubmitting: boolean;
+  isDialogOpen: boolean;
+  setIsDialogOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  onSubmit: (data: EditTitlePayload) => void;
+}
+
+export const EditTitleDialog: React.FC<Props> = (props) => {
+  const {
+    dialogTitle,
+    submitButtonLabel,
+    isDialogOpen,
+    isSubmitting,
+    setIsDialogOpen,
+    onSubmit,
+  } = props;
+  const { register, formState, handleSubmit } =
+    useFormContext<EditTitlePayload>();
+
+  return (
+    <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
+      <DialogContent className="sm:max-w-[425px]">
+        <form noValidate onSubmit={handleSubmit(onSubmit)}>
+          <DialogHeader>
+            <DialogTitle>{dialogTitle}</DialogTitle>
+            <DialogDescription></DialogDescription>
+          </DialogHeader>
+          <div className="my-6">
+            <label
+              htmlFor="title"
+              className="mb-1 block font-bold text-gray-700"
+            >
+              タイトル
+            </label>
+            <TextInputField
+              {...register("title")}
+              id="title"
+              type="text"
+              error={!!formState.errors.title}
+            />
+            <FormFieldErrorMsg msg={formState.errors.title?.message} />
+            <input type="hidden" id="id" {...register("id")} />
+          </div>
+
+          <DialogFooter>
+            <ActionButton
+              type="submit"
+              isBusy={isSubmitting}
+              disabled={!formState.isValid || isSubmitting}
+            >
+              {submitButtonLabel}
+            </ActionButton>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/src/app/teacher/sessions/_hooks/useTableColumns.tsx
+++ b/src/app/teacher/sessions/_hooks/useTableColumns.tsx
@@ -5,6 +5,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import datetime2str from "@/app/_utils/datetime2str";
 import {
   faPen,
+  faClock,
   faSort,
   faEllipsisVertical,
   faClone,
@@ -36,14 +37,14 @@ const useTableColumns = ({
   deleteSession,
 }: RowActionHandlers): ColumnDef<SessionSummary>[] => {
   //
-  const handleRename = useCallback(
+  const renameTitle = useCallback(
     async (id: string, currentValue: string) => {
       await updateSessionSummary(id, "title", currentValue);
     },
     [updateSessionSummary]
   );
 
-  const handleSwitchActiveState = useCallback(
+  const switchActiveState = useCallback(
     async (id: string, currentValue: boolean) => {
       await updateSessionSummary(id, "isActive", !currentValue);
     },
@@ -54,11 +55,22 @@ const useTableColumns = ({
     () => [
       {
         accessorKey: "title",
-        header: () => <div className="font-bold">ラーニングセッション</div>,
+        header: ({ column }) => (
+          <div className="font-bold">
+            ラーニングセッション
+            <FontAwesomeIcon
+              className="ml-1 cursor-pointer text-slate-400 hover:text-slate-700"
+              icon={faSort}
+              onClick={() =>
+                column.toggleSorting(column.getIsSorted() === "asc")
+              }
+            />
+          </div>
+        ),
         cell: ({ row }) => {
           const id = row.original.id;
           const session = row.original;
-          const href = `/learning-session/${session.accessCode}`;
+          const href = `/teacher/sessions/${session.accessCode}`;
           return (
             <div
               className={twMerge(
@@ -72,7 +84,7 @@ const useTableColumns = ({
               <FontAwesomeIcon
                 className="ml-1 cursor-pointer text-xs text-slate-300 hover:text-slate-600"
                 icon={faPen}
-                onClick={() => handleRename(id, session.title)}
+                onClick={() => renameTitle(id, session.title)}
               />
             </div>
           );
@@ -92,7 +104,7 @@ const useTableColumns = ({
                 type="checkbox"
                 className="size-4 sm:size-5"
                 checked={isActive}
-                onChange={() => handleSwitchActiveState(id, isActive)}
+                onChange={() => switchActiveState(id, isActive)}
                 readOnly
               />
             </div>
@@ -174,7 +186,7 @@ const useTableColumns = ({
                 </DropdownMenuTrigger>
                 <DropdownMenuContent>
                   <DropdownMenuItem
-                    onClick={() => handleRename(id, title)}
+                    onClick={() => renameTitle(id, title)}
                     className="cursor-pointer"
                   >
                     <FontAwesomeIcon icon={faPen} className="mr-2" />
@@ -201,7 +213,7 @@ const useTableColumns = ({
         },
       },
     ],
-    [handleRename, handleSwitchActiveState]
+    [deleteSession, renameTitle, switchActiveState]
   );
 };
 

--- a/src/app/teacher/sessions/_hooks/useTableColumns.tsx
+++ b/src/app/teacher/sessions/_hooks/useTableColumns.tsx
@@ -1,0 +1,208 @@
+import React, { useMemo, useCallback } from "react";
+import { ColumnDef } from "@tanstack/react-table";
+import { SessionSummary } from "@/app/_types/SessionTypes";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import datetime2str from "@/app/_utils/datetime2str";
+import {
+  faPen,
+  faSort,
+  faEllipsisVertical,
+  faClone,
+  faTrash,
+  faUser,
+  faFileLines,
+} from "@fortawesome/free-solid-svg-icons";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/app/_components/shadcn/ui/dropdown-menu";
+import Link from "@/app/_components/elements/Link";
+import { twMerge } from "tailwind-merge";
+
+interface RowActionHandlers {
+  deleteSession: (id: string) => Promise<void>;
+  updateSessionSummary: <K extends keyof SessionSummary>(
+    id: string,
+    key: K,
+    value: SessionSummary[K]
+  ) => Promise<void>;
+}
+
+const useTableColumns = ({
+  updateSessionSummary,
+  deleteSession,
+}: RowActionHandlers): ColumnDef<SessionSummary>[] => {
+  //
+  const handleRename = useCallback(
+    async (id: string, currentValue: string) => {
+      await updateSessionSummary(id, "title", currentValue);
+    },
+    [updateSessionSummary]
+  );
+
+  const handleSwitchActiveState = useCallback(
+    async (id: string, currentValue: boolean) => {
+      await updateSessionSummary(id, "isActive", !currentValue);
+    },
+    [updateSessionSummary]
+  );
+
+  return useMemo(
+    () => [
+      {
+        accessorKey: "title",
+        header: () => <div className="font-bold">ラーニングセッション</div>,
+        cell: ({ row }) => {
+          const id = row.original.id;
+          const session = row.original;
+          const href = `/learning-session/${session.accessCode}`;
+          return (
+            <div
+              className={twMerge(
+                "text-base",
+                !session.isActive && "text-gray-300"
+              )}
+            >
+              <Link href={href} style="unstyled">
+                {session.title}
+              </Link>
+              <FontAwesomeIcon
+                className="ml-1 cursor-pointer text-xs text-slate-300 hover:text-slate-600"
+                icon={faPen}
+                onClick={() => handleRename(id, session.title)}
+              />
+            </div>
+          );
+        },
+      },
+
+      {
+        accessorKey: "isActive",
+        header: () => <div className="text-center font-bold sm:px-1">有効</div>,
+        cell: ({ row }) => {
+          const id = row.original.id;
+          const isActive = row.original.isActive;
+          return (
+            <div className="flex justify-center">
+              <input
+                name={`isActive_${id}`}
+                type="checkbox"
+                className="size-4 sm:size-5"
+                checked={isActive}
+                onChange={() => handleSwitchActiveState(id, isActive)}
+                readOnly
+              />
+            </div>
+          );
+        },
+      },
+
+      {
+        accessorKey: "enrollmentCount",
+        header: () => (
+          <div className="hidden px-1 text-center sm:block sm:px-2">
+            <FontAwesomeIcon icon={faUser} />
+          </div>
+        ),
+        cell: ({ row }) => {
+          const enrollmentCount = row.original.enrollmentCount;
+          return (
+            <div className="hidden text-center sm:block">{enrollmentCount}</div>
+          );
+        },
+      },
+
+      {
+        accessorKey: "questionsCount",
+        header: () => (
+          <div className="hidden px-1 text-center sm:block sm:px-2">
+            <FontAwesomeIcon icon={faFileLines} />
+          </div>
+        ),
+        cell: ({ row }) => {
+          const questionsCount = row.original.questionsCount;
+          return (
+            <div className="hidden text-center sm:block">{questionsCount}</div>
+          );
+        },
+      },
+
+      {
+        accessorKey: "createdAt",
+        header: ({ column }) => (
+          <div className="text-center font-bold">
+            作成日
+            <FontAwesomeIcon
+              className="ml-1 cursor-pointer text-slate-400 hover:text-slate-700"
+              icon={faSort}
+              onClick={() =>
+                column.toggleSorting(column.getIsSorted() === "asc")
+              }
+            />
+          </div>
+        ),
+        cell: ({ row }) => {
+          const updatedAt = row.original.createdAt;
+          return (
+            <div className="flex flex-col justify-center text-center text-xs">
+              <div>
+                <span className="hidden sm:inline-block">
+                  {datetime2str(updatedAt, "YYYY/")}
+                </span>
+                {datetime2str(updatedAt, "MM/DD")}
+              </div>
+              <div>{datetime2str(updatedAt, "HH:mm")}</div>
+            </div>
+          );
+        },
+      },
+      {
+        id: "actions",
+        cell: ({ row }) => {
+          const id = row.original.id;
+          const title = row.original.title;
+          return (
+            <div>
+              <DropdownMenu modal={false}>
+                <DropdownMenuTrigger asChild className="focus:outline-none">
+                  <div className="flex justify-center px-3 py-1 text-slate-400 hover:cursor-pointer hover:text-slate-700">
+                    <FontAwesomeIcon icon={faEllipsisVertical} />
+                  </div>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent>
+                  <DropdownMenuItem
+                    onClick={() => handleRename(id, title)}
+                    className="cursor-pointer"
+                  >
+                    <FontAwesomeIcon icon={faPen} className="mr-2" />
+                    名前の変更
+                  </DropdownMenuItem>
+                  <DropdownMenuItem className="cursor-pointer">
+                    <Link href="#" style="nav" state="notImplemented">
+                      <FontAwesomeIcon icon={faClone} className="mr-2" />
+                      複製
+                    </Link>
+                  </DropdownMenuItem>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuItem
+                    onClick={() => deleteSession(id)}
+                    className="cursor-pointer"
+                  >
+                    <FontAwesomeIcon icon={faTrash} className="mr-2" />
+                    削除
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            </div>
+          );
+        },
+      },
+    ],
+    [handleRename, handleSwitchActiveState]
+  );
+};
+
+export default useTableColumns;

--- a/src/app/teacher/sessions/page.tsx
+++ b/src/app/teacher/sessions/page.tsx
@@ -256,7 +256,7 @@ const Page: React.FC = () => {
         />
       </FormProvider>
 
-      <Accordion type="single" collapsible defaultValue={accordionValue}>
+      {/* <Accordion type="single" collapsible defaultValue={accordionValue}>
         <AccordionItem value="item-1" className="border-0">
           <AccordionTrigger className="text-slate-500 hover:cursor-pointer">
             <div>
@@ -269,7 +269,7 @@ const Page: React.FC = () => {
             <BeginnersGuide />
           </AccordionContent>
         </AccordionItem>
-      </Accordion>
+      </Accordion> */}
     </div>
   );
 };

--- a/src/app/teacher/sessions/page.tsx
+++ b/src/app/teacher/sessions/page.tsx
@@ -1,0 +1,277 @@
+"use client";
+
+import React, { useState, useCallback, useMemo } from "react";
+import { useForm, FormProvider } from "react-hook-form";
+
+// カスタムフック・APIリクエスト系
+import useAuthenticatedGetRequest from "@/app/_hooks/useAuthenticatedGetRequest";
+import {
+  createPostRequest,
+  createPutRequest,
+  createDeleteRequest,
+} from "@/app/_utils/createApiRequest";
+import { ApiResponse } from "@/app/_types/ApiResponse";
+import SuccessResponseBuilder from "@/app/api/_helpers/successResponseBuilder";
+import useTableColumns from "./_hooks/useTableColumns";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useRouter } from "next/navigation";
+import useAuth from "@/app/_hooks/useAuth";
+import { StatusCodes } from "@/app/_utils/extendedStatusCodes";
+
+// UIコンポーネント
+import PageTitle from "@/app/_components/elements/PageTitle";
+import LoadingSpinner from "@/app/_components/elements/LoadingSpinner";
+import { SessionTable } from "./_components/SessionTable";
+import BeginnersGuide from "./_components/BeginnersGuide";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/app/_components/shadcn/ui/accordion";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faChildReaching } from "@fortawesome/free-solid-svg-icons";
+import { EditTitleDialog } from "./_components/TitleEditorDialog";
+
+// 型・定数・ユーティリティ
+import { produce, Draft } from "immer";
+import {
+  SessionSummary,
+  CreateSessionRequest,
+  UpdateSessionRequest,
+} from "@/app/_types/SessionTypes";
+import {
+  editTitlePayloadSchema,
+  EditTitlePayload,
+} from "./_components/TitleEditorDialog";
+import ActionButton from "@/app/_components/elements/ActionButton";
+
+enum Mode {
+  Creation = "creation",
+  Modification = "modification",
+}
+
+const Page: React.FC = () => {
+  let accordionValue = undefined;
+
+  const c_Id = "id";
+  const c_Title = "title";
+  const getEp = "/api/v1/teacher/sessions";
+  const postEp = "/api/v1/teacher/sessions/new";
+  const { apiRequestHeader } = useAuth();
+  const { data, mutate } = useAuthenticatedGetRequest<SessionSummary[]>(getEp);
+  const [isSubmitting, setIsSubmitting] = React.useState(false);
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const [titleEditMode, setTitleEditMode] = useState<Mode>(Mode.Modification);
+
+  const [dialogTitle, setDialogTitle] = useState("");
+  const [dialogSubmitButtonLabel, setDialogSubmitButtonLabel] = useState("");
+
+  const router = useRouter();
+
+  // prettier-ignore
+  const postApiCaller = useMemo(() => createPostRequest<CreateSessionRequest, ApiResponse<SessionSummary>>(),[]);
+  // prettier-ignore
+  const putApiCaller = useMemo(() => createPutRequest<UpdateSessionRequest, ApiResponse<null>>(),[]);
+  // prettier-ignore
+  const deleteApiCaller = useMemo(() => createDeleteRequest<ApiResponse<null>>(),[]);
+
+  // セッションのタイトルの設定（新規・変更）に使用するフォーム
+  const titleEditFormMethods = useForm<EditTitlePayload>({
+    mode: "onChange",
+    resolver: zodResolver(editTitlePayloadSchema),
+  });
+
+  // タイトル設定ダイアログのSubmit処理
+  const onEditTitleSubmit = async (payload: EditTitlePayload) => {
+    setIsSubmitting(true);
+    payload.title = payload.title.trim();
+    console.log("■ >>> " + JSON.stringify(payload));
+    let res: ApiResponse<any>;
+    try {
+      //
+      switch (titleEditMode) {
+        // [セッションの新規作成]
+        case Mode.Creation:
+          res = await postApiCaller(postEp, payload, apiRequestHeader);
+          if (!res.success) new Error(res.error.technicalInfo);
+          router.push(`/teacher/sessions/${res.data.accessCode!}`);
+          break;
+
+        // [セッションのタイトルの更新]
+        case Mode.Modification:
+          const { id, title } = payload;
+          // 楽観的UI更新処理
+          const newData = produce(
+            data?.data,
+            (draft: Draft<SessionSummary[]>) => {
+              const target = draft.find((s) => s.id === id);
+              if (target) target.title = title;
+            }
+          );
+          const optimisticRes = new SuccessResponseBuilder(newData!)
+            .setHttpStatus(StatusCodes.OK)
+            .build();
+          mutate(optimisticRes, false);
+
+          // 実際の更新リクエスト
+          const putEp = `/api/v1/teacher/sessions/${id}`;
+          const reqBody: UpdateSessionRequest = {
+            id: id!,
+            title: title,
+          };
+          res = await putApiCaller(putEp, reqBody, apiRequestHeader);
+          break;
+      }
+    } catch (error) {
+      let msg = "処理に失敗";
+      msg += error instanceof Error ? `\n${error.message}` : "";
+      alert(msg);
+    } finally {
+      console.log("■ <<< " + JSON.stringify(res!));
+      setIsSubmitting(false);
+      setIsDialogOpen(false);
+    }
+  };
+
+  // セッションの [新規作成]ボタン の押下処理
+  const createSessionAction = () => {
+    setTitleEditMode(Mode.Creation);
+    setDialogTitle("ラーニングセッションの新規作成");
+    setDialogSubmitButtonLabel("作成");
+    titleEditFormMethods.setValue(c_Title, "");
+    titleEditFormMethods.setValue(c_Id, "");
+    titleEditFormMethods.clearErrors();
+    setIsDialogOpen(true);
+  };
+
+  // 既存セッションの属性の更新処理
+  const updateSessionSummary = useCallback(
+    async <K extends keyof SessionSummary>(
+      id: string,
+      key: K,
+      value: SessionSummary[K]
+    ): Promise<void> => {
+      // タイトルだけはダイアログ表示の必要性があるので別処理
+      if (key === c_Title) {
+        setTitleEditMode(Mode.Modification);
+        setDialogTitle("ラーニングセッションのタイトル編集");
+        setDialogSubmitButtonLabel("変更");
+        titleEditFormMethods.setValue(c_Title, value as string);
+        titleEditFormMethods.setValue(c_Id, id);
+        titleEditFormMethods.clearErrors();
+        setIsDialogOpen(true);
+        // 以降は onEditTitleSubmit で処理される
+        return;
+      }
+
+      try {
+        // 楽観的UI更新処理
+        const newData = produce(
+          data?.data,
+          (draft: Draft<SessionSummary[]>) => {
+            const target = draft.find((s) => s.id === id);
+            if (target) target[key] = value;
+          }
+        );
+        const optimisticRes = new SuccessResponseBuilder(newData!)
+          .setHttpStatus(StatusCodes.OK)
+          .build();
+        mutate(optimisticRes, false);
+
+        // 実際の更新リクエスト
+        const postEp = `/api/v1/teacher/sessions/${id}`;
+        const reqBody: UpdateSessionRequest = {
+          id: id,
+          [key]: value,
+        };
+        const res = await putApiCaller(postEp, reqBody, apiRequestHeader);
+        res.error && console.error(JSON.stringify(res.error, null, 2));
+        // 負荷軽減のため、mutate() の実行は一旦保留
+        // mutate();
+
+        return; // 更新成功
+      } catch (error) {
+        console.error("Session update failed:", error);
+        return; // 更新失敗
+      }
+    },
+    [apiRequestHeader, data?.data, mutate, putApiCaller, titleEditFormMethods]
+  );
+
+  // 既存セッションの削除処理
+  const deleteSession = useCallback(
+    async (id: string): Promise<void> => {
+      // あとでいい感じに
+      if (!confirm("削除してもよろしいですか？")) return;
+
+      // 楽観的UI更新処理
+      const newData = produce(data?.data, (draft: Draft<SessionSummary[]>) => {
+        const targetIndex = draft.findIndex((s) => s.id === id);
+        if (targetIndex !== -1) draft.splice(targetIndex, 1);
+      });
+      const optimisticRes = new SuccessResponseBuilder(newData!)
+        .setHttpStatus(StatusCodes.OK)
+        .build();
+      mutate(optimisticRes, false);
+
+      // 実際の削除リクエスト
+      const deleteEp = `/api/v1/teacher/sessions/${id}`;
+      const res = await deleteApiCaller(deleteEp, apiRequestHeader);
+      res.error && console.error(JSON.stringify(res.error, null, 2));
+    },
+    [apiRequestHeader, data?.data, deleteApiCaller, mutate]
+  );
+
+  const columns = useTableColumns({ updateSessionSummary, deleteSession });
+
+  return (
+    <div>
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between sm:gap-0">
+        <div>
+          <PageTitle title="ラーニングセッションの管理" />
+        </div>
+
+        <div className="flex flex-row justify-end">
+          <ActionButton onClick={createSessionAction}>新規作成</ActionButton>
+        </div>
+      </div>
+
+      <div className="mt-4 px-0 md:px-2">
+        {data?.data ? (
+          <SessionTable columns={columns} data={data.data} />
+        ) : (
+          <LoadingSpinner message="バックグラウンドでデータを読み込んでいます..." />
+        )}
+      </div>
+
+      <FormProvider {...titleEditFormMethods}>
+        <EditTitleDialog
+          dialogTitle={dialogTitle}
+          submitButtonLabel={dialogSubmitButtonLabel}
+          isSubmitting={isSubmitting}
+          isDialogOpen={isDialogOpen}
+          setIsDialogOpen={setIsDialogOpen}
+          onSubmit={onEditTitleSubmit}
+        />
+      </FormProvider>
+
+      <Accordion type="single" collapsible defaultValue={accordionValue}>
+        <AccordionItem value="item-1" className="border-0">
+          <AccordionTrigger className="text-slate-500 hover:cursor-pointer">
+            <div>
+              <FontAwesomeIcon icon={faChildReaching} className="mr-1.5" />
+              Beginner&rsquo;s Guide
+              <FontAwesomeIcon icon={faChildReaching} className="ml-1.5" />
+            </div>
+          </AccordionTrigger>
+          <AccordionContent>
+            <BeginnersGuide />
+          </AccordionContent>
+        </AccordionItem>
+      </Accordion>
+    </div>
+  );
+};
+
+export default Page;

--- a/src/app/user/profile/page.tsx
+++ b/src/app/user/profile/page.tsx
@@ -52,7 +52,6 @@ const UserProfilePage: React.FC = () => {
   }, [cache]);
 
   // フォーム状態管理
-
   const methods = useForm<UserProfile>({
     mode: "onChange",
     resolver: zodResolver(userProfileSchema),


### PR DESCRIPTION
【実装の概要】
- ラーニングセッションの一覧表示、新規作成、削除、名前変更などを行なうためのフロントエンドを実装しました。具体的には `/teacher/sessions` のページを実装しました。

【特にレビューして頂きたいファイル】
- `/teacher/sessions/page.tsx`
- `/teacher/sessions/_components/SessionTable.tsx`
- `/teacher/sessions/_components/TitleEditorDialog.tsx`
- `/teacher/sessions/_hooks/useTableColumns.tsx`