### PR TITLE
ログイン後のリダイレクト処理の強化

### DIFF
--- a/src/app/_components/shadcn/ui/dialog.tsx
+++ b/src/app/_components/shadcn/ui/dialog.tsx
@@ -38,7 +38,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-1/2 top-1/2 z-50 grid w-full max-w-lg translate-x-1/2 translate-y-1/2 gap-4 border border-slate-200 bg-white p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] dark:border-slate-800 dark:bg-slate-950 sm:rounded-lg",
+        "fixed left-1/2 top-1/2 z-50 grid w-full max-w-lg -translate-x-1/2 -translate-y-1/2 gap-4 border border-slate-200 bg-white p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] dark:border-slate-800 dark:bg-slate-950 sm:rounded-lg",
         className
       )}
       {...props}

--- a/src/app/_components/shadcn/ui/toast.tsx
+++ b/src/app/_components/shadcn/ui/toast.tsx
@@ -34,7 +34,7 @@ const toastVariants = cva(
         success:
           "px-3 py-2 success group border-green-300 bg-green-100 text-green-800 dark:border-green-800 dark:bg-green-900 dark:text-green-100",
         destructive:
-          "destructive group border-red-500 bg-red-500 text-slate-50 dark:border-red-900 dark:bg-red-900 dark:text-slate-50",
+          "px-3 py-2 destructive group border-red-500 bg-red-500 text-slate-50 dark:border-red-900 dark:bg-red-900 dark:text-slate-50",
       },
     },
     defaultVariants: {

--- a/src/app/_components/shadcn/ui/toaster.tsx
+++ b/src/app/_components/shadcn/ui/toaster.tsx
@@ -9,9 +9,7 @@ import {
   ToastTitle,
   ToastViewport,
 } from "@/app/_components/shadcn/ui/toast";
-import { Check } from "lucide-react"; // Lucide Reactからチェックアイコンをインポート
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faCircleCheck } from "@fortawesome/free-solid-svg-icons";
+import { Check, X } from "lucide-react";
 
 export function Toaster() {
   const { toasts } = useToast();
@@ -34,10 +32,9 @@ export function Toaster() {
                 <ToastDescription>
                   {variant === "success" && (
                     <Check className="mr-1.5 inline-block size-4" />
-                    // <FontAwesomeIcon
-                    //   icon={faCircleCheck}
-                    //   className="mr-2 inline-block size-4"
-                    // />
+                  )}
+                  {variant === "destructive" && (
+                    <X className="mr-1.5 inline-block size-4" />
                   )}
                   {description}
                 </ToastDescription>

--- a/src/app/_hooks/useRouteGuard.ts
+++ b/src/app/_hooks/useRouteGuard.ts
@@ -18,6 +18,9 @@ const useRouteGuard = (requiredRole: Role, returnPath: string) => {
       return;
     }
 
+    // userProfileが取得できるまで認可の評価を保留
+    if (!userProfile) return;
+
     // ADMIN権限が要求されるページに、ADMIN以外がアクセスした
     if (requiredRole === Role.ADMIN && userProfile?.role !== Role.ADMIN) {
       toast({

--- a/src/app/_hooks/useRouteGuard.ts
+++ b/src/app/_hooks/useRouteGuard.ts
@@ -1,19 +1,54 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import useAuth from "@/app/_hooks/useAuth";
+import { Role } from "@/app/_types/UserTypes";
+import { useToast } from "@/app/_components/shadcn/hooks/use-toast";
 
-const useRouteGuard = () => {
+const useRouteGuard = (requiredRole: Role, returnPath: string) => {
   const router = useRouter();
-  const { session, isLoading, userProfile } = useAuth();
-
+  const { isLoading, userProfile, session } = useAuth();
+  const [isAuthorized, setIsAuthorized] = useState(false);
+  const { toast } = useToast();
   useEffect(() => {
-    if (!isLoading && !session) {
-      router.replace("/");
-    }
-  }, [isLoading, session, router]);
+    if (isLoading) return;
 
-  // !!session は session !== null && session !== undefined と同じ
-  return { isAuthenticated: !!session, isLoading, role: userProfile?.role };
+    // ログインしていなければログインページにリダイレクト
+    if (!session) {
+      router.replace(`/login?returnPath=${returnPath}`);
+      return;
+    }
+
+    // ADMIN権限が要求されるページに、ADMIN以外がアクセスした
+    if (requiredRole === Role.ADMIN && userProfile?.role !== Role.ADMIN) {
+      toast({
+        description: `${returnPath} は管理者権限が必要です。`,
+        variant: "destructive",
+      });
+      router.replace("/");
+      return;
+    }
+    // TEACHER権限が要求されるページに、STUDENT (=ADMIN・TEACHERが以外) がアクセスした
+    if (requiredRole === Role.TEACHER && userProfile?.role === Role.STUDENT) {
+      toast({
+        description: `${returnPath} は教員権限が必要です。`,
+        variant: "destructive",
+      });
+      router.replace("/");
+      return;
+    }
+    setIsAuthorized(true);
+  }, [
+    isLoading,
+    router,
+    returnPath,
+    requiredRole,
+    userProfile,
+    toast,
+    session,
+  ]);
+
+  // ログインかつアクセス権限 (認可) があるかどうかを返す
+  return { isAuthorized, isLoading };
 };
 
 export default useRouteGuard;

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -4,7 +4,7 @@ import React from "react";
 import useRouteGuard from "@/app/_hooks/useRouteGuard";
 import LoadingPage from "@/app/_components/LoadingPage";
 import { Role } from "@/app/_types/UserTypes";
-import { useRouter } from "next/navigation";
+import { usePathname } from "next/navigation";
 
 interface Props {
   children: React.ReactNode;
@@ -12,22 +12,16 @@ interface Props {
 
 const Layout: React.FC<Props> = (props) => {
   const { children } = props;
-  const { isAuthenticated, isLoading, role } = useRouteGuard();
-  const router = useRouter();
+  const { isAuthorized, isLoading } = useRouteGuard(Role.ADMIN, usePathname());
 
   if (isLoading) {
     return <LoadingPage />;
   }
 
-  // 認証を終えるまでは何も表示しない
-  if (!isAuthenticated) return null;
+  if (isLoading) return <LoadingPage />;
 
-  // 管理者以外のときはトップページにリダイレクト
-  if (role !== Role.ADMIN) {
-    router.replace("/");
-    return null;
-  }
-
+  // 認可がない場合は何も表示しない
+  if (!isAuthorized) return null;
   return <>{children}</>;
 };
 

--- a/src/app/login/layout.tsx
+++ b/src/app/login/layout.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import React from "react";
+import { Suspense } from "react";
+
+interface Props {
+  children: React.ReactNode;
+}
+
+const Layout: React.FC<Props> = (props) => {
+  const { children } = props;
+  return <Suspense>{children}</Suspense>;
+};
+
+export default Layout;

--- a/src/app/login/oauth/callback/google/page.tsx
+++ b/src/app/login/oauth/callback/google/page.tsx
@@ -7,7 +7,7 @@ import { RedirectTo } from "@/app/_types/RedirectTo";
 import LoadingPage from "@/app/_components/LoadingPage";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faCircleExclamation } from "@fortawesome/free-solid-svg-icons";
-import useAuth from "@/app/_hooks/useAuth";
+import { useSearchParams } from "next/navigation";
 
 export default function OAuthCallback() {
   const router = useRouter();
@@ -16,12 +16,10 @@ export default function OAuthCallback() {
 
   const getApiCaller = createGetRequest<ApiResponse<RedirectTo>>();
 
-  const [returnPath, setReturnPath] = useState<string | null>(null);
-  useEffect(() => {
-    const searchParams = new URLSearchParams(window.location.search);
-    const rawReturnPath = searchParams.get("returnPath");
-    setReturnPath(rawReturnPath?.startsWith("http") ? null : rawReturnPath);
-  }, []);
+  // returnPath の取得（オープンリダイレクト対処付き）
+  const searchParams = useSearchParams();
+  const rawReturnPath = searchParams.get("returnPath");
+  const returnPath = rawReturnPath?.startsWith("http") ? null : rawReturnPath;
 
   useEffect(() => {
     const hash = window.location.hash.substring(1);

--- a/src/app/login/oauth/callback/google/page.tsx
+++ b/src/app/login/oauth/callback/google/page.tsx
@@ -7,7 +7,7 @@ import { RedirectTo } from "@/app/_types/RedirectTo";
 import LoadingPage from "@/app/_components/LoadingPage";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faCircleExclamation } from "@fortawesome/free-solid-svg-icons";
-import Link from "@/app/_components/elements/Link";
+import useAuth from "@/app/_hooks/useAuth";
 
 export default function OAuthCallback() {
   const router = useRouter();
@@ -15,6 +15,13 @@ export default function OAuthCallback() {
   const [error, setError] = useState<string | null>(null);
 
   const getApiCaller = createGetRequest<ApiResponse<RedirectTo>>();
+
+  const [returnPath, setReturnPath] = useState<string | null>(null);
+  useEffect(() => {
+    const searchParams = new URLSearchParams(window.location.search);
+    const rawReturnPath = searchParams.get("returnPath");
+    setReturnPath(rawReturnPath?.startsWith("http") ? null : rawReturnPath);
+  }, []);
 
   useEffect(() => {
     const hash = window.location.hash.substring(1);
@@ -38,18 +45,25 @@ export default function OAuthCallback() {
           Authorization: accessToken,
         };
         const res = await getApiCaller(ep, apiRequestHeader);
-        // ロールやユーザステート（初回ログインなど）に合わせたリダイレクト
+
+        // ログイン後のリダイレクト処理
         if (res.success) {
+          // クエリで returnPath が与えられていれば、それを優先する。
+          if (returnPath) {
+            router.replace(returnPath);
+            return;
+          }
           router.replace(res.data?.redirectTo!);
           return;
         }
+
         console.error("■ ログイン処理に失敗:", JSON.stringify(res, null, 2));
       } catch (e) {
         console.error("ユーザー情報の登録に失敗:", e);
       }
     };
     postUser();
-  }, [accessToken, error, getApiCaller, router]);
+  }, [accessToken, error, getApiCaller, returnPath, router]);
 
   if (error === "access_denied") {
     return (

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,6 +1,8 @@
 "use client";
+
 import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
+import { useSearchParams } from "next/navigation";
 
 // カスタムフック・APIリクエスト系
 import { supabase } from "@/lib/supabase";
@@ -34,6 +36,13 @@ const LoginPage: React.FC = () => {
   const router = useRouter();
   const [isLoggedIn, setIsLoggedIn] = useState<boolean>(false);
   const { setIsUserProfileRefreshRequired, logout } = useAuth();
+
+  const [returnPath, setReturnPath] = useState<string | null>(null);
+  useEffect(() => {
+    const searchParams = new URLSearchParams(window.location.search);
+    const rawReturnPath = searchParams.get("returnPath");
+    setReturnPath(rawReturnPath?.startsWith("http") ? null : rawReturnPath);
+  }, []);
 
   const c_Email = "email";
   const c_Password = "password";
@@ -101,8 +110,13 @@ const LoginPage: React.FC = () => {
       apiRequestHeader
     );
 
-    // ロールやユーザステート（初回ログインなど）に合わせたリダイレクト
+    // ログイン後のリダイレクト処理
     if (res.success) {
+      // クエリで returnPath が与えられていれば、それを優先する。
+      if (returnPath) {
+        router.replace(returnPath);
+        return;
+      }
       router.replace(res.data?.redirectTo!);
       return;
     }

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -37,12 +37,17 @@ const LoginPage: React.FC = () => {
   const [isLoggedIn, setIsLoggedIn] = useState<boolean>(false);
   const { setIsUserProfileRefreshRequired, logout } = useAuth();
 
-  const [returnPath, setReturnPath] = useState<string | null>(null);
-  useEffect(() => {
-    const searchParams = new URLSearchParams(window.location.search);
-    const rawReturnPath = searchParams.get("returnPath");
-    setReturnPath(rawReturnPath?.startsWith("http") ? null : rawReturnPath);
-  }, []);
+  // returnPath の取得（オープンリダイレクト対処付き）
+  const searchParams = useSearchParams();
+  const rawReturnPath = searchParams.get("returnPath");
+  const returnPath = rawReturnPath?.startsWith("http") ? null : rawReturnPath;
+
+  // const [returnPath, setReturnPath] = useState<string | null>(null);
+  // useEffect(() => {
+  //   const searchParams = new URLSearchParams(window.location.search);
+  //   const rawReturnPath = searchParams.get("returnPath");
+  //   setReturnPath(rawReturnPath?.startsWith("http") ? null : rawReturnPath);
+  // }, []);
 
   const c_Email = "email";
   const c_Password = "password";

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -74,15 +74,13 @@ const LoginPage: React.FC = () => {
   const fieldErrors = form.formState.errors;
 
   const oAuthLogin = async () => {
+    const queryParam = returnPath ? `?returnPath=${returnPath}` : "";
+    const redirectTo = `${appBaseUrl}/login/oauth/callback/google${queryParam}`;
     const { error } = await supabase.auth.signInWithOAuth({
       provider: "google",
-      options: {
-        redirectTo: `${appBaseUrl}/login/oauth/callback/google`,
-      },
+      options: { redirectTo },
     });
-    if (error) {
-      setErrorMsg(`${error.message}`);
-    }
+    if (error) setErrorMsg(error.message);
   };
 
   const onSubmit = async (formValues: UserAuth) => {

--- a/src/app/student/layout.tsx
+++ b/src/app/student/layout.tsx
@@ -3,6 +3,8 @@
 import React from "react";
 import useRouteGuard from "@/app/_hooks/useRouteGuard";
 import LoadingPage from "@/app/_components/LoadingPage";
+import { Role } from "@/app/_types/UserTypes";
+import { usePathname } from "next/navigation";
 
 interface Props {
   children: React.ReactNode;
@@ -10,15 +12,15 @@ interface Props {
 
 const Layout: React.FC<Props> = (props) => {
   const { children } = props;
-  const { isAuthenticated, isLoading } = useRouteGuard();
+  const { isAuthorized, isLoading } = useRouteGuard(
+    Role.STUDENT,
+    usePathname()
+  );
 
-  if (isLoading) {
-    return <LoadingPage />;
-  }
+  if (isLoading) return <LoadingPage />;
 
-  // 認証を終えるまでは何も表示しない
-  if (!isAuthenticated) return null;
-
+  // 認可がない場合は何も表示しない
+  if (!isAuthorized) return null;
   return <>{children}</>;
 };
 

--- a/src/app/teacher/layout.tsx
+++ b/src/app/teacher/layout.tsx
@@ -4,7 +4,7 @@ import React from "react";
 import useRouteGuard from "@/app/_hooks/useRouteGuard";
 import LoadingPage from "@/app/_components/LoadingPage";
 import { Role } from "@/app/_types/UserTypes";
-import { useRouter } from "next/navigation";
+import { usePathname } from "next/navigation";
 
 interface Props {
   children: React.ReactNode;
@@ -12,22 +12,15 @@ interface Props {
 
 const Layout: React.FC<Props> = (props) => {
   const { children } = props;
-  const { isAuthenticated, isLoading, role } = useRouteGuard();
-  const router = useRouter();
+  const { isAuthorized, isLoading } = useRouteGuard(
+    Role.TEACHER,
+    usePathname()
+  );
 
-  if (isLoading) {
-    return <LoadingPage />;
-  }
+  if (isLoading) return <LoadingPage />;
 
-  // 認証を終えるまでは何も表示しない
-  if (!isAuthenticated) return null;
-
-  // 管理者もしくは教員ではないとき（つまり学生のとき）
-  if (role === Role.STUDENT) {
-    router.replace("/");
-    return null;
-  }
-
+  // 認可がない場合は何も表示しない
+  if (!isAuthorized) return null;
   return <>{children}</>;
 };
 

--- a/src/app/user/layout.tsx
+++ b/src/app/user/layout.tsx
@@ -3,6 +3,8 @@
 import React from "react";
 import useRouteGuard from "@/app/_hooks/useRouteGuard";
 import LoadingPage from "@/app/_components/LoadingPage";
+import { Role } from "@/app/_types/UserTypes";
+import { usePathname } from "next/navigation";
 
 interface Props {
   children: React.ReactNode;
@@ -10,16 +12,15 @@ interface Props {
 
 const Layout: React.FC<Props> = (props) => {
   const { children } = props;
-  const { isAuthenticated, isLoading } = useRouteGuard();
+  const { isAuthorized, isLoading } = useRouteGuard(
+    Role.STUDENT,
+    usePathname()
+  );
 
-  if (isLoading) {
-    return <LoadingPage />;
-  }
+  if (isLoading) return <LoadingPage />;
 
-  if (!isAuthenticated) {
-    return null; // 認証されていない場合は何も表示しない
-  }
-  // ログイン(認証済み)が確認できてから子コンポーネントをレンダリング
+  // 認可がない場合は何も表示しない
+  if (!isAuthorized) return null;
   return <>{children}</>;
 };
 


### PR DESCRIPTION
【実装の概要】
- 未ログイン状態で認証・認可が必要なページ（例えば `/teacher/sessions` ）にアクセスしたとき、ログインページ（`/login`）にリダイレクトし、ログイン後に元の要求ページ（ `/teacher/sessions` ）にリダイレクトする機能を実装しました。
- 上記にあわせてルートガード関連の処理を整理しました。