### PR TITLE
教員ロールのゲスト機能の実装

### DIFF
--- a/src/app/api/v1/student/sessions/[id]/enroll/route.ts
+++ b/src/app/api/v1/student/sessions/[id]/enroll/route.ts
@@ -94,7 +94,7 @@ export const DELETE = async (req: NextRequest, { params: { id } }: Params) => {
     // ユーザが存在しない場合は UserService.NotFoundError がスローされる
     const appUser = await userService.getById(authUser.id);
 
-    // ゲストユーザから要求を拒否
+    // ゲストユーザからの要求を拒否
     if (appUser.isGuest) {
       throw new GuestNotAllowedError(appUser.id, appUser.displayName);
     }

--- a/src/app/api/v1/teacher/sessions/new/route.ts
+++ b/src/app/api/v1/teacher/sessions/new/route.ts
@@ -8,6 +8,7 @@ import {
   ApiError,
   ZodValidationError,
   NonTeacherOperationError,
+  GuestNotAllowedError,
 } from "@/app/api/_helpers/apiExceptions";
 
 // ユーザ認証・サービスクラス関係
@@ -27,7 +28,7 @@ import {
 
 export const revalidate = 0; // キャッシュを無効化
 
-// [POST] /api/v1/teacher/sessions/new　セッションの新規作成
+// [POST] /api/v1/teacher/sessions/new セッションの新規作成
 export const POST = async (req: NextRequest) => {
   const userService = new UserService(prisma);
   const sessionService = new SessionService(prisma);
@@ -43,6 +44,11 @@ export const POST = async (req: NextRequest) => {
     // ユーザーが 教員 または 管理者 のロールを持たない場合は Error がスローされる
     if (appUser.role === Role.STUDENT) {
       throw new NonTeacherOperationError(appUser.id, appUser.displayName);
+    }
+
+    // ゲストユーザからの要求を拒否
+    if (appUser.isGuest) {
+      throw new GuestNotAllowedError(appUser.id, appUser.displayName);
     }
 
     // リクエストボディの検証

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -49,6 +49,7 @@ const LoginPage: React.FC = () => {
   const c_Password = "password";
 
   const guestStudentNum = 2;
+  const guestTeacherNum = 1;
 
   useEffect(() => {
     const checkSession = async () => {
@@ -273,7 +274,10 @@ const LoginPage: React.FC = () => {
         </div>
       </div>
 
-      <PageTitle title="ゲスト利用" />
+      <PageTitle title="お試し利用（ゲストログイン）" />
+      <div className="mt-2 text-sm" id="guest-login">
+        ゲストログインした場合は一部の機能がご利用になれません。
+      </div>
       <div className="mt-4 flex flex-wrap gap-x-2">
         {[...Array(guestStudentNum)]
           .map((_, i) => i + 1)
@@ -287,6 +291,23 @@ const LoginPage: React.FC = () => {
                 onClick={() => guestLogin(Role.STUDENT, n)}
               >
                 学生{String(n).padStart(2, "0")}
+              </ActionButton>
+            </div>
+          ))}
+      </div>
+      <div className="mb-4 mt-1 flex flex-wrap gap-x-2">
+        {[...Array(guestTeacherNum)]
+          .map((_, i) => i + 1)
+          .map((n) => (
+            <div key={n} className="mb-2">
+              <ActionButton
+                tabIndex={-1}
+                type="button"
+                variant="indigo"
+                width="slim"
+                onClick={() => guestLogin(Role.TEACHER, n)}
+              >
+                教員{String(n).padStart(2, "0")}
               </ActionButton>
             </div>
           ))}

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -138,9 +138,19 @@ const SignUpPage: React.FC = () => {
         <p>無料で利用できる ProgressLens にようこそ。</p>
         <p className="text-sm">
           はじめに、メールアドレスを使ってサインアップしていきましょう。
-          <br />
-          以下で設定したメールに届いた「認証リンク」をクリックすれば利用の準備は完了です。
+          以下のフォームで設定したメールアドレスに届いた「認証リンク」をクリックすれば利用の準備は完了です。
         </p>
+        <ul className="ml-2 list-inside list-disc text-sm">
+          <li>
+            体験利用（登録せずにゲストログイン）は
+            <Link href="/login#guest-login">こちら</Link>
+          </li>
+
+          <li>
+            Googleアカウントでソーシャルログインする場合は
+            <Link href="/login">こちら</Link>
+          </li>
+        </ul>
       </div>
 
       <div className="mt-5">
@@ -208,7 +218,7 @@ const SignUpPage: React.FC = () => {
         </div>
       </div>
 
-      <div className="mt-6 space-y-2 break-all text-sm">
+      <div className="my-4 space-y-2 break-all text-sm">
         <div>
           <FontAwesomeIcon
             icon={faComment}

--- a/src/app/student/sessions/_hooks/useStudentSessionTableColumns.tsx
+++ b/src/app/student/sessions/_hooks/useStudentSessionTableColumns.tsx
@@ -27,7 +27,7 @@ import {
 import Link from "@/app/_components/elements/Link";
 import { twMerge } from "tailwind-merge";
 
-interface SessionRowContext {
+interface RowActionHandlers {
   isGuest: boolean;
   confirmUnenrollSession: (id: string, name: string) => Promise<void>;
 }
@@ -35,7 +35,7 @@ interface SessionRowContext {
 const useStudentSessionTableColumns = ({
   isGuest,
   confirmUnenrollSession,
-}: SessionRowContext): ColumnDef<SessionSummary>[] => {
+}: RowActionHandlers): ColumnDef<SessionSummary>[] => {
   //
 
   return useMemo(
@@ -162,7 +162,7 @@ const useStudentSessionTableColumns = ({
                     <FontAwesomeIcon icon={faEllipsisVertical} />
                   </div>
                 </DropdownMenuTrigger>
-                <DropdownMenuContent>
+                <DropdownMenuContent className="mr-1">
                   {isGuest ? (
                     <DropdownMenuItem>
                       <div className="cursor-not-allowed text-gray-500">

--- a/src/app/teacher/sessions/[id]/page.tsx
+++ b/src/app/teacher/sessions/[id]/page.tsx
@@ -436,7 +436,7 @@ const Page: React.FC = () => {
           </ActionButton>
         </div>
 
-        <div className="mb-4 flex justify-end">
+        <div className="mb-4 mt-5 flex justify-end">
           <Link href="/teacher/sessions" className="">
             <FontAwesomeIcon icon={faChalkboardUser} className="mr-1" />
             セッション一覧

--- a/src/app/teacher/sessions/_hooks/useTeacherSessionTableColumns.tsx
+++ b/src/app/teacher/sessions/_hooks/useTeacherSessionTableColumns.tsx
@@ -5,6 +5,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import datetime2str from "@/app/_utils/datetime2str";
 import {
   faPen,
+  faPenToSquare,
   faBoltLightning,
   faSort,
   faEllipsisVertical,
@@ -30,6 +31,7 @@ import Link from "@/app/_components/elements/Link";
 import { twMerge } from "tailwind-merge";
 
 interface RowActionHandlers {
+  isGuest: boolean;
   confirmDeleteSession: (id: string, name: string) => Promise<void>;
   confirmDuplicateSession: (id: string, name: string) => Promise<void>;
   updateSessionSummary: <K extends keyof SessionSummary>(
@@ -40,6 +42,7 @@ interface RowActionHandlers {
 }
 
 const useTeacherSessionTableColumns = ({
+  isGuest,
   updateSessionSummary,
   confirmDuplicateSession,
   confirmDeleteSession,
@@ -93,8 +96,8 @@ const useTeacherSessionTableColumns = ({
                 <Tooltip>
                   <TooltipTrigger asChild>
                     <FontAwesomeIcon
-                      className="ml-1 cursor-pointer text-xs text-indigo-300 hover:text-indigo-500"
-                      icon={faPen}
+                      className="ml-1.5 cursor-pointer text-xs text-indigo-300 hover:text-indigo-500"
+                      icon={faPenToSquare}
                       onClick={() => renameTitle(id, session.title)}
                     />
                   </TooltipTrigger>
@@ -154,22 +157,6 @@ const useTeacherSessionTableColumns = ({
           );
         },
       },
-
-      // {
-      //   accessorKey: "questionsCount",
-      //   header: () => (
-      //     <div className="hidden px-1 text-center sm:block sm:px-2">
-      //       <FontAwesomeIcon icon={faFileLines} />
-      //     </div>
-      //   ),
-      //   cell: ({ row }) => {
-      //     const questionsCount = row.original.questionsCount;
-      //     return (
-      //       <div className="hidden text-center sm:block">{questionsCount}</div>
-      //     );
-      //   },
-      // },
-
       {
         accessorKey: "createdAt",
         header: ({ column }) => (
@@ -218,7 +205,7 @@ const useTeacherSessionTableColumns = ({
                     <FontAwesomeIcon icon={faEllipsisVertical} />
                   </div>
                 </DropdownMenuTrigger>
-                <DropdownMenuContent>
+                <DropdownMenuContent className="mr-1">
                   <DropdownMenuItem
                     onClick={() => renameTitle(id, title)}
                     className="cursor-pointer"
@@ -226,21 +213,40 @@ const useTeacherSessionTableColumns = ({
                     <FontAwesomeIcon icon={faPen} className="mr-2" />
                     名前の変更
                   </DropdownMenuItem>
-                  <DropdownMenuItem
-                    onClick={() => confirmDuplicateSession(id, title)}
-                    className="cursor-pointer"
-                  >
-                    <FontAwesomeIcon icon={faClone} className="mr-2" />
-                    複製
-                  </DropdownMenuItem>
+                  {isGuest ? (
+                    <DropdownMenuItem>
+                      <div className="cursor-not-allowed text-gray-500">
+                        <FontAwesomeIcon icon={faClone} className="mr-2" />
+                        複製（ゲストは利用不可）
+                      </div>
+                    </DropdownMenuItem>
+                  ) : (
+                    <DropdownMenuItem
+                      onClick={() => confirmDuplicateSession(id, title)}
+                      className="cursor-pointer"
+                    >
+                      <FontAwesomeIcon icon={faClone} className="mr-2" />
+                      複製
+                    </DropdownMenuItem>
+                  )}
+
                   <DropdownMenuSeparator />
-                  <DropdownMenuItem
-                    onClick={() => confirmDeleteSession(id, title)}
-                    className="cursor-pointer"
-                  >
-                    <FontAwesomeIcon icon={faTrash} className="mr-2" />
-                    削除
-                  </DropdownMenuItem>
+                  {isGuest ? (
+                    <DropdownMenuItem>
+                      <div className="cursor-not-allowed text-gray-500">
+                        <FontAwesomeIcon icon={faTrash} className="mr-2" />
+                        削除（ゲストは利用不可）
+                      </div>
+                    </DropdownMenuItem>
+                  ) : (
+                    <DropdownMenuItem
+                      onClick={() => confirmDeleteSession(id, title)}
+                      className="cursor-pointer"
+                    >
+                      <FontAwesomeIcon icon={faTrash} className="mr-2" />
+                      削除
+                    </DropdownMenuItem>
+                  )}
                 </DropdownMenuContent>
               </DropdownMenu>
             </div>
@@ -251,6 +257,7 @@ const useTeacherSessionTableColumns = ({
     [
       confirmDeleteSession,
       confirmDuplicateSession,
+      isGuest,
       renameTitle,
       switchActiveState,
     ]


### PR DESCRIPTION
【実装の概要】
教員ロールのゲスト機能（ゲストログイン機能）を実装しました。

- 登録ログインした教員と同じ画面表示を維持しつつ、以下の制限を与えるようにしました（フロントエンドとバックエンドの両方で制限）。
    - ゲストは、ラーニングセッションの新規作成・複製・削除ができない。
    - 既存のラーニングセッション（＝管理側で予め用意しておく）については、設問や回答選択肢の追加・編集・削除ができる。
- ログイン画面（`/login`）に、教員ロールのゲストログインボタンを追加しました。